### PR TITLE
changes sts for symlink and variable consistency

### DIFF
--- a/docs/rosa/sts/README.md
+++ b/docs/rosa/sts/README.md
@@ -24,7 +24,7 @@ This is a summary of the [official docs](https://docs.openshift.com/rosa/rosa_ge
     git clone https://github.com/openshift/cloud-credential-operator.git
     cd cloud-credential-operator/cmd/ccoctl
     go build .
-    mv ccoctl /usr/local/bin/ccoctl
+    ln -s $(pwd)/ccoctl /usr/local/bin/ccoctl
     ccoctl --help
     ```
 
@@ -252,7 +252,7 @@ Once the cluster has finished installing we can validate we can access it
 1. Create an Admin user
 
     ```bash
-    rosa create admin -c $cluster
+    rosa create admin -c $name
     ```
 
 1. Wait a few moments and run the `oc login` command it provides.
@@ -262,13 +262,13 @@ Once the cluster has finished installing we can validate we can access it
 1. Delete the ROSA cluster
 
     ```bash
-    rosa delete cluster -c $cluster
+    rosa delete cluster -c $name
     ```
 
 1. Watch the logs and wait until the cluster is deleted
 
     ```bash
-    rosa logs uninstall -c $cluster --watch
+    rosa logs uninstall -c $name --watch
     ```
 
 1. Clean up the STS roles


### PR DESCRIPTION
in `docs/rosa/sts/README.md`

changes setup for ccoctl to use symlink method instead of move for resulting binary
changes `$cluster` in the final Validation and Cleanup steps to `$name` for consistency with the rest of the document

The latter change it's possible instead we want to change all instances of `$name` to `$cluster` instead for consistency with other docs. 