### PR TITLE
Fix the yaml for spellchecker and update revision to .16

### DIFF
--- a/.github/config/.spellcheck.yml
+++ b/.github/config/.spellcheck.yml
@@ -1,19 +1,19 @@
 matrix:
-- name: Markdown
-  aspell:
-    ignore-case: true
-    lang: en
-  dictionary:
-    wordlists:
-    - .github/config/.wordlist.txt
-    encoding: utf-8
-  pipeline:
-  - pyspelling.filters.markdown:
-  - pyspelling.filters.html:
-    comments: false
-    ignores:
-    - code
-    - pre
-  sources:
-  - '**/*.md'
-  default_encoding: utf-8
+  - name: Markdown
+    aspell:
+      ignore-case: true
+      lang: en
+    dictionary:
+      wordlists:
+        - .github/config/.wordlist.txt
+      encoding: utf-8
+    pipeline:
+      - pyspelling.filters.markdown:
+      - pyspelling.filters.html:
+          comments: false
+          ignores:
+            - code
+            - pre
+    sources:
+      - "**/*.md"
+    default_encoding: utf-8

--- a/.github/workflows/github-actions-spellcheck.yaml
+++ b/.github/workflows/github-actions-spellcheck.yaml
@@ -7,7 +7,7 @@ jobs:
     continue-on-error: true
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.14.0
+    - uses: rojopolis/spellcheck-github-actions@0.16.0
       name: Spellcheck
       with:
         config_path: .github/config/.spellcheck.yml


### PR DESCRIPTION
Fix malformatted YAML and update to .16.   Failure word list appears much smaller ignoring code blocks correctly and we may be able to track a smaller group of custom words.