### PR TITLE
Docswarning

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,7 +67,7 @@
   <a href="https://github.com/rh-mobb/documentation" target="_blank">GitHub</a>
 </div>
     <main id="content" class="main-content" role="main">
-      <br><pre><code>Officially supported documentation is available at https://docs.openshift.com.</code></pre><br>
+      <br><pre><code>Disclaimer: Mobb.ninja is not official Red Hat documentation - These guides may be experimental, proof of concept or early adoption. Officially supported documentation is available at https://docs.openshift.com.</code></pre><br>
       {{ content }}
 
       <footer class="site-footer">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,6 +67,7 @@
   <a href="https://github.com/rh-mobb/documentation" target="_blank">GitHub</a>
 </div>
     <main id="content" class="main-content" role="main">
+      <br><pre><code>Officially supported documentation is available at https://docs.openshift.com.</code></pre><br>
       {{ content }}
 
       <footer class="site-footer">


### PR DESCRIPTION
Add a warning box for documentation on mobb.ninja - should show up in all content pages (not necessarily in the github repo since github doesn't use jekyll theme in source code)