### PR TITLE
add tle ELB notes to the simple rosa getting started guide

### DIFF
--- a/docs/quickstart-rosa.md
+++ b/docs/quickstart-rosa.md
@@ -94,6 +94,12 @@ _You'll need to have an AWS account to configure the CLI against._
     }
     ```
 
+4. If this is a brand new AWS account that has never had a AWS Load Balancer installed in it, you should run the following
+
+    ```bash
+    aws iam create-service-linked-role --aws-service-name \
+    "elasticloadbalancing.amazonaws.com"
+    ```
 
 ### Get a Red Hat Offline Access Token
 


### PR DESCRIPTION
add the notes about the missing ELB  role for new vpcs to rosa quick start guide

    aws iam create-service-linked-role --aws-service-name \
    "elasticloadbalancing.amazonaws.com"
