### PR TITLE
use specified version for jekyll container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ build:
 	docker run --rm \
 	  --name=jekyll-build \
 		--volume="$(PWD):/srv/jekyll" \
-		-it jekyll/jekyll:3.8 \
+		-it jekyll/jekyll:3.8.6 \
 		jekyll build
 
 preview:
@@ -10,5 +10,5 @@ preview:
 		--name=jekyll-preview \
 		--volume="$(PWD):/srv/jekyll" \
 		--publish 4000:4000 \
-		jekyll/jekyll \
+		jekyll/jekyll:3.8.6 \
 		jekyll serve


### PR DESCRIPTION
The preview is breaking, since Jekyll released a new docker image latest. We should use a tag for preview and build in make file. 3.8.6 is the latest 3 version