### PR TITLE
Remove clusterName specified twice

### DIFF
--- a/docs/rosa/alb-sts/README.md
+++ b/docs/rosa/alb-sts/README.md
@@ -1,6 +1,6 @@
 # Installing the AWS Load Balancer Controller (ALB) on ROSA
 
-*Updated: 02/22/2022*
+*Updated: 06/09/2022*
 
 In most situations you will want to stick with the OpenShift native Ingress Controller in order to use the native Ingress and Route resources to provide access to your applications.  However if you absolutely require an ALB or NLB based Load Balancer then running the AWS Load Balancer Controller (ALB) may be worth looking at.
 
@@ -167,7 +167,7 @@ echo $VPC
     helm repo add eks https://aws.github.io/eks-charts
     helm repo update
     helm upgrade alb-controller eks/aws-load-balancer-controller -i \
-      -n $NAMESPACE --set clusterName=$CLUSTER_NAME \
+      -n $NAMESPACE \
       --set serviceAccount.name=$SA \
       --set "vpcId=$VPC" \
       --set "region=$REGION" \


### PR DESCRIPTION
clusterName is specified twice in the helm values. The first one is wrong but is overridden by the second. So this removes the first (wrong) one