### PR TITLE
Fix policy-document reference for cw iam policy

### DIFF
--- a/docs/rosa/cluster-metrics-to-aws-prometheus/README.md
+++ b/docs/rosa/cluster-metrics-to-aws-prometheus/README.md
@@ -145,7 +145,7 @@ EOF
 
     ```bash
     CW_POLICY=$(aws iam create-policy --policy-name $PROM_SA-cw \
-      --policy-document file://$SCRATCH_DIR/PermissionPolicyIngest.json \
+      --policy-document file://$SCRATCH_DIR/PermissionPolicyCloudWatch.json \
       --query 'Policy.Arn' --output text)
     echo $CW_POLICY
     ```


### PR DESCRIPTION
$PROM_SA-cw iam policy referenced $SCRATCH_DIR/PermissionPolicyIngest.json policy-document which was created and used for $PROM_SA-prom iam policy.