### PR TITLE
removing the space in the Allow Egress rule collection name

### DIFF
--- a/docs/aro/private-cluster.md
+++ b/docs/aro/private-cluster.md
@@ -240,7 +240,7 @@ This replaces the routes for the cluster to go through the Firewall for egress v
 
         ```bash
         az network firewall application-rule create -g $AZR_RESOURCE_GROUP -f aro-private     \
-            --collection-name 'Allow Egress'                                                  \
+            --collection-name 'Allow_Egress'                                                  \
             --action allow                                                                    \
             --priority 100                                                                    \
             -n 'required'                                                                     \


### PR DESCRIPTION
(InvalidResourceName) Resource name Allow Egress is invalid. The name can be up to 80 characters long. It must begin with a word character, and it must end with a word character or with '_'. The name may contain word characters or '.', '-', '_'.
Code: InvalidResourceName
Message: Resource name Allow Egress is invalid. The name can be up to 80 characters long. It must begin with a word character, and it must end with a word character or with '_'. The name may contain word characters or '.', '-', '_'.

Fixing this bug in Firewall Rule Collection name for allowing https traffic