### PR TITLE
Fix typo on Azure ARO GPU Instance Type

### DIFF
--- a/docs/aro/gpu/README.md
+++ b/docs/aro/gpu/README.md
@@ -54,7 +54,7 @@ ARO supports the following GPU workers:
 * NC4as T4 v3
 * NC8as T4 v3
 * NC16as T4 v3
-* NC464as T4 v3
+* NC64as T4 v3
 
 >Please remember that when you request quota that Azure is per core.  To request a single NC4as T4 v3 node, you will need to request quota in groups of 4. If you wish to request an NC16as T4 v3 you will need to request quota of 16.
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/openshift/howto-gpu-workloads#request-gpu-quota is wrong as well. 

NCas T4 v3 instance types can be found here: https://docs.microsoft.com/en-us/azure/virtual-machines/nct4-v3-series
