### PR TITLE
change CNAME target from endpoint name to CLB name

### DIFF
--- a/docs/rosa/private-link/public-ingress.md
+++ b/docs/rosa/private-link/public-ingress.md
@@ -114,7 +114,7 @@ The is an example guide for creating a public ingress endpoint for a ROSA Privat
        name: acme-tls
        namespace: my-custom-route
    EOF
-```
+   ```
 
 1. Wait for the domain to be ready:
 
@@ -122,14 +122,15 @@ The is an example guide for creating a public ingress endpoint for a ROSA Privat
    watch oc get customdomains
    ```
 
-1. Once its ready grab the endpoint:
+1. Once its ready grab the CLB name:
 
-   ```bash
-   ENDPOINT=$(oc get customdomains acme -o jsonpath='{.status.endpoint}')
-   echo $ENDPOINT
+   ```
+   export CDO_NAME=acme
+   CLB_NAME=$(oc get svc -n openshift-ingress -o jsonpath='{range .items[?(@.metadata.labels.ingresscontroller\.operator\.openshift\.io\/owning-ingresscontroller=="acme")]}{.status.loadBalancer.ingress[].hostname}{"\n"}{end}')
+   echo $CLB_NAME
    ```
 
-1. Create a CNAME in your DNS provider for *.<$DOMAIN> that points at the endpoint from the above command.
+1. Create a CNAME in your DNS provider for *.<$DOMAIN> that points at the CLB name from the above command.
 
 ### Deploy a public application
 


### PR DESCRIPTION
In a private cluster with PrivateLink, the customdomain endpoint is created in a private Route53 zone of ROSA.
And domain names belonging to private Route53 zones can't be resolved from the internet, but I needed to make the sample application using the CDO accessible from the internet.

The customdomain endpoint is "alias"ed to the external CLB name created by CDO like the below.

*.acme.mycluster.12ab.p1.openshiftapps.com   A   a9db5fabcd1234-972115757.ap-northeast-1.elb.amazonaws.com.
( customdomain endpoint)                                       ( CLB name ) 

So, I changed the CNAME target from customdomain endpoint to the CLB domain name so that the sample application can be accessed from the internet.