### PR TITLE
adding sshuttle install, fixing aro create indent

### DIFF
--- a/content/docs/aro/private-cluster.md
+++ b/content/docs/aro/private-cluster.md
@@ -26,6 +26,12 @@ _Obviously you'll need to have an Azure account to configure the CLI against._
     brew update && brew install azure-cli
     ```
 
+2. Install sshuttle using homebrew
+
+    ```bash
+    brew install sshuttle
+    ```
+
 **Linux**
 
 > See [Azure Docs](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=dnf) for alternative install options.
@@ -52,7 +58,7 @@ _Obviously you'll need to have an Azure account to configure the CLI against._
 1. Install Azure CLI
 
     ```bash
-    sudo dnf install -y azure-cli
+    sudo dnf install -y azure-cli sshuttle
     ```
 
 ### Prepare Azure Account for Azure OpenShift
@@ -347,7 +353,9 @@ This replaces the routes for the cluster to go through the Firewall for egress v
     --route-table aro-udr
     ```
 
-1. Create the cluster
+### Create the cluster
+
+Create the cluster
 
     > This will take between 30 and 45 minutes.
 


### PR DESCRIPTION
adding sshuttle install command for macos and linux prereqs, getting 'aro create cluster' command out of prev section's indentation, also i might do another PR on this one next week