### PR TITLE
Disable copy button on inline code

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -39,7 +39,7 @@ menushortcutsnewtab = true
 # #editURL = "https://github.com/vjeantet/hugo-theme-docport/edit/master/exampleSite/content/"
 # enableGitInfo = true
 
-
+disableInlineCopyToClipBoard = true # Don't display the copy-to-clipboard button on inline code blocks, default is false
 
 [mediaTypes]
   [mediaTypes."application/netlifyconfig"]


### PR DESCRIPTION
Change the hugo configuration for our template to display the copy-to-clipboard button only on fenced or indented code blocks, not inline code that is surrounded by single backticks.

In our docs, we are consistent about using fenced or indented code blocks when we have an example that we intend someone to copy-paste, and we use inline code to denote that something is literal.