### PR TITLE
Adding missing extra-scopes flag to IdP creation

### DIFF
--- a/content/docs/idp/azuread-aro/_index.md
+++ b/content/docs/idp/azuread-aro/_index.md
@@ -121,6 +121,7 @@ spec:
       extraScopes: 
       - profile
       - openid
+      - email
       issuer: https://login.microsoftonline.com/${TENANT_ID}/v2.0
     type: OpenID
 EOF

--- a/content/docs/idp/azuread/_index.md
+++ b/content/docs/idp/azuread/_index.md
@@ -91,7 +91,8 @@ rosa create idp \
     --issuer-url https://login.microsoftonline.com/${TENANT_ID}/v2.0 \
     --email-claims email \
     --name-claims name \
-    --username-claims preferred_username
+    --username-claims preferred_username \
+    --extra-scopes email,profile
 ```
 
 ## 4. Grant additional permissions to individual users


### PR DESCRIPTION
Customers using the GroupSync Operator are consistently running into this issue because our docs have changed and are missing configuration required to make the IdP pass tokens that match up with the users created in `Group` resources by the GSO.

Namely, when querying Azure, the IdP config needs to ask for the `email` and `profile` scopes in addition to the default `opened` one, otherwise the fields don't through correctly and the user ends up being represented as their Azure UUID rather than their e-mail, which is what GroupSync assumes.

We should probably re-work our IdP config docs as they're getting pretty scattered and seem to have some inconsistencies in them.