### PR TITLE
docs/idp/group-claims/aro: Fix to use a valid date stamp

### DIFF
--- a/content/docs/idp/group-claims/aro/_index.md
+++ b/content/docs/idp/group-claims/aro/_index.md
@@ -1,5 +1,5 @@
 ---
-date: '2023-05-24T22:07:09.954151'
+date: '2023-05-24T11:26:30.000000'
 title: Configure ARO to use Azure AD Group Claims
 ---
 

--- a/content/docs/idp/group-claims/aro/_index.md
+++ b/content/docs/idp/group-claims/aro/_index.md
@@ -1,5 +1,5 @@
 ---
-date: '2023-05-24T11:26:30.000000'
+date: '2023-05-24'
 title: Configure ARO to use Azure AD Group Claims
 ---
 

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text }}</a>


### PR DESCRIPTION
The invalid date stamp prevented the page from being generated.