### PR TITLE
feat: add prereqs and summary as front matter params

### DIFF
--- a/content/docs/rosa/egress-ip/_index.md
+++ b/content/docs/rosa/egress-ip/_index.md
@@ -4,26 +4,24 @@ title: Assign Consistent Egress IP for External Traffic
 tags: ["OSD", "ROSA", "ARO"]
 authors:
   - 'Dustin Scott'
+summary: |
+  It may be desirable to assign a consistent IP address for traffic that leaves 
+  the cluster when configuring items such as security groups or other sorts of 
+  security controls which require an IP-based configuration.  By default, 
+  Kubernetes via the OVN-Kubernetes CNI will assign random IP addresses from a pool 
+  which will make configuring security lockdowns unpredictable or 
+  unnecessarily open.  This guide shows you how to configure a set of predictable 
+  IP addresses for egress cluster traffic to meet common security standards and 
+  guidance and other potential use cases.
+
+  See the [OpenShift documentation on this topic](https://docs.openshift.com/container-platform/4.12/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html) 
+  for more information.
+prereqs:
+  - ROSA Cluster (4.10+)
+  - openshift-cli (`oc`)
+  - rosa-cli (`rosa`)
+  - jq
 ---
-
-It may be desirable to assign a consistent IP address for traffic that leaves 
-the cluster when configuring items such as security groups or other sorts of 
-security controls which require an IP-based configuration.  By default, 
-Kubernetes via the OVN-Kubernetes CNI will assign random IP addresses from a pool 
-which will make configuring security lockdowns unpredictable or 
-unnecessarily open.  This guide shows you how to configure a set of predictable 
-IP addresses for egress cluster traffic to meet common security standards and 
-guidance and other potential use cases.
-
-See the [OpenShift documentation on this topic](https://docs.openshift.com/container-platform/4.12/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html) 
-for more information.
-
-## Prerequisites
-
-* ROSA Cluster
-* openshift-cli (`oc`)
-* rosa-cli (`rosa`)
-* jq
 
 ## Demo
 

--- a/layouts/partials/heading-post.html
+++ b/layouts/partials/heading-post.html
@@ -46,3 +46,24 @@
 </p>
 <hr>
 {{ end }}
+
+<!-- summary comes from the summary metadata -->
+<!-- if summary is unset, the content provided in the markdown file should provide the summary -->
+<!-- markdown is able to be included for the summary -->
+{{ if isset .Params "summary" }}
+    {{ "## Summary" | markdownify }}
+    {{ .Params.Summary | markdownify }}
+{{ end }}
+
+<!-- preqreqs comes from the prereqs metadata -->
+<!-- if prereqs is unset, it is up to the user to provide prereqs for this walkthrough (or it may not be a walkthrough) -->
+<!-- markdown is able to be included for the prereqs -->
+{{ if isset .Params "prereqs" }}
+    {{ "## Prerequisite Tooling" | markdownify }}
+    The following tooling must be installed prior to beginning this walkthrough:<br>
+    {{ range $prereq := .Params.Prereqs }}
+        <ul>
+            <li>{{ $prereq | markdownify }}</li>
+        </ul>
+    {{ end }}
+{{ end }}


### PR DESCRIPTION
This addresses the following:

- Adds `summary` into the front matter and will print a `Summary` as a header 2 with the information in the summary front matter as part of the header
- Adds `prereqs` into the front matter and will print a list of prereqs
- This is to address consistency for each of the pages as this happens on 99% of the articles
- Markdown is supported in both of these fields to allow for flexibility
- Skips displaying this information if those are not specified in the front matter
- Displays below the metadata from PR #346 

Example:

<img width="1046" alt="image" src="https://github.com/rh-mobb/documentation/assets/13810795/a957c3fe-02f8-4aaf-9365-0d25484c41ed">
