### PR TITLE
Yank cluster name correctly in log forwarding guide

### DIFF
--- a/content/docs/rosa/clf-cloudwatch-sts/_index.md
+++ b/content/docs/rosa/clf-cloudwatch-sts/_index.md
@@ -22,7 +22,7 @@ This guide shows how to deploy the Cluster Log Forwarder operator and configure 
    > Change the cluster name to match your ROSA cluster and ensure you're logged into the cluster as an Administrator. Ensure all fields are outputted correctly before moving on.
 
    ```bash
-   export ROSA_CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\+$//')
+   export ROSA_CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
    export REGION=$(rosa describe cluster -c ${ROSA_CLUSTER_NAME} --output json | jq -r .region.id)
    export OIDC_ENDPOINT=$(oc get authentication.config.openshift.io cluster -o json | jq -r .spec.serviceAccountIssuer | sed  's|^https://||')
    export AWS_ACCOUNT_ID=`aws sts get-caller-identity --query Account --output text`


### PR DESCRIPTION
original command did not strip out alphanumeric identifier in cluster name