### PR TITLE
Move ARO docs that had been under ROSA

### DIFF
--- a/content/docs/aro/static-ip-load-balancer/index.md
+++ b/content/docs/aro/static-ip-load-balancer/index.md
@@ -5,6 +5,8 @@ tags: ["AWS", "ROSA"]
 authors:
   - Michael McNeill
   - Connor Wooley
+aliases:
+  - "/docs/rosa/static-ip-load-balancer/"
 ---
 
 This guide demonstrates how to create and assign a static public IP address to an OpenShift service in Azure Red Hat OpenShift (ARO). By default, the public IP address assigned to an OpenShift service with a type of LoadBalancer created by an ARO cluster is only valid for the lifespan of that resource. If you delete the OpenShift service, the associated load balancer and IP address are also deleted. If you want to assign a specific IP address or retain an IP address for redeployed OpenShift services, you can create and use a static public IP address.

--- a/content/docs/aro/user-workload-monitoring/index.md
+++ b/content/docs/aro/user-workload-monitoring/index.md
@@ -3,6 +3,8 @@ date: '2021-06-07'
 title: User Workload Monitoring on Azure Red Hat OpenShift
 authors:
   - Paul Czarkowski
+aliases:
+  - "/docs/rosa/federated-metrics/user-defined/"
 ---
 
 In Azure Red Hat OpenShift (ARO) Monitoring for User Defined Projects is disabled by default. Follow these instructions to enable it.


### PR DESCRIPTION
The documents "Configure A Load Balancer Service To Use A Static Public IP" and "User Workload Monitoring on Azure Red Hat OpenShift" are both about ARO but were incorrectly filed under the ROSA directory.

Move them to their correct locations and add aliases so that any use of the previous URLs still redirects to the new locations.