### PR TITLE
docs/idp/group-claims/aro: Restrict firewall rule to port 443

### DIFF
--- a/content/docs/idp/group-claims/aro/_index.md
+++ b/content/docs/idp/group-claims/aro/_index.md
@@ -166,7 +166,7 @@ az network firewall network-rule create -g $AZR_RESOURCE_GROUP -f aro-private   
     --collection-name 'Allow_Microsoft_Graph' --action allow --priority 100     \
     -n 'Microsoft_Graph' --source-address '*' --protocols 'any'                 \
     --source-addresses '*' --destination-fqdns 'graph.microsoft.com'            \
-    --destination-ports '*'
+    --destination-ports '443'
 ```
 
 Now you should be able to login choosing the AAD option:


### PR DESCRIPTION
The Microsoft Graph API is documented to respond on the standard HTTPS port, so that is the only port we need to allow through.

Quote the documentation:
> The Microsoft Graph API offers a single endpoint, https://graph.microsoft.com/

Reference: https://learn.microsoft.com/en-us/graph/overview