### PR TITLE
Update cloud-front.md

### DIFF
--- a/content/docs/rosa/waf/cloud-front.md
+++ b/content/docs/rosa/waf/cloud-front.md
@@ -84,6 +84,7 @@ authors:
       name: acme
     spec:
       domain: $DOMAIN
+      loadBalancerType: Classic or NLB
       certificate:
         name: acme-tls
         namespace: my-custom-route
@@ -110,15 +111,15 @@ authors:
 
     > Make sure you create it in the US-EAST-1 region (otherwise cloud front can't use it)
 
-1. Log into the [AWS console and Create a Cloud Front distribution](https://console.aws.amazon.com/cloudfront/home?region=us-east-2#create-distribution:) (make sure its the same region as your cluster).
+1. Log into the [AWS console and Create a Cloud Front distribution](https://console.aws.amazon.com/cloudfront/home?region=us-east-2#create-distribution:) 
 
-    * Origin Domain Name: <Endpoint from oc get manageddomains command>
+    * Origin Domain Name: < Endpoint from oc get manageddomains command >
     * Origin Protocol Policy: HTTPS only
     * Viewer Protocol Policy: Redirect HTTP to HTTPS
     * Allowed HTTP Methods: GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE
     * AWS WAF Web ACL: demo-waf-acl
-    * Alternate Domain Names: *.<domain>
-    * Custom SSL Certificate: <the one you just imported>
+    * Alternate Domain Names: *.< domain >
+    * Custom SSL Certificate: < the one you just imported >
     * Origin Request Policy: create a new policy whitelist: Origin, user-agent, referer, host (**IMPORTANT**)
 
 1. Hit **Create** then wait until the **Status** is *Ready*.

--- a/content/docs/rosa/waf/cloud-front.md
+++ b/content/docs/rosa/waf/cloud-front.md
@@ -74,7 +74,7 @@ authors:
     oc create secret tls acme-tls --cert=$CERTS/fullchain1.pem --key=$CERTS/privkey1.pem
     ```
 
-1. Create a Custom Domain resource
+1. Create a Custom Domain resource. (You can change the load balancer from the default Classic by adding spec.loadBalancerType: NLB to the following YAML)
 
     ```bash
     cat << EOF | oc apply -f -
@@ -84,7 +84,7 @@ authors:
       name: acme
     spec:
       domain: $DOMAIN
-      loadBalancerType: Classic or NLB
+      loadBalancerType: Classic
       certificate:
         name: acme-tls
         namespace: my-custom-route


### PR DESCRIPTION
- Updated CustomDomain CR to reflect NLB capability
- Removed instruction to create Cloudfront in same region as cluster. Cloudfront is a global service 
- Fixed minor syntax error, added spaces after < and before > in Cloudfront distribution creation instructions. Instructions in angle brackets < > are currently not displayed on Mobb.ninja. 