### PR TITLE
Adding missing '--extra-scopes' parameter to IdP create command

### DIFF
--- a/content/docs/idp/group-claims/rosa/_index.md
+++ b/content/docs/idp/group-claims/rosa/_index.md
@@ -100,7 +100,8 @@ rosa create idp \
     --email-claims email \
     --name-claims name \
     --username-claims preferred_username \
-    --groups-claims groups
+    --groups-claims groups \
+    --extra-scopes email,profile
 ```
 
 ## 4. Grant additional permissions to individual groups


### PR DESCRIPTION
Without the `--extra-scopes` parameter, the IdP doesn't return all of the needed claims and it's unable to match Users to the Groups that come through in the claims.