### PR TITLE
Remove service endpoints and update PL note

### DIFF
--- a/content/docs/aro/private-cluster.md
+++ b/content/docs/aro/private-cluster.md
@@ -154,8 +154,7 @@ Create a virtual network with two empty subnets
       --resource-group $AZR_RESOURCE_GROUP                            \
       --vnet-name "$AZR_CLUSTER-aro-vnet-$AZR_RESOURCE_LOCATION"      \
       --name "$AZR_CLUSTER-aro-control-subnet-$AZR_RESOURCE_LOCATION" \
-      --address-prefixes $CONTROL_SUBNET                              \
-      --service-endpoints Microsoft.ContainerRegistry
+      --address-prefixes $CONTROL_SUBNET                              
     ```
 
 1. Create machine subnet
@@ -165,13 +164,12 @@ Create a virtual network with two empty subnets
       --resource-group $AZR_RESOURCE_GROUP                              \
       --vnet-name "$AZR_CLUSTER-aro-vnet-$AZR_RESOURCE_LOCATION"        \
       --name "$AZR_CLUSTER-aro-machine-subnet-$AZR_RESOURCE_LOCATION"   \
-      --address-prefixes $MACHINE_SUBNET                                \
-      --service-endpoints Microsoft.ContainerRegistry
+      --address-prefixes $MACHINE_SUBNET                                
     ```
 
-1. [Disable network policies](https://docs.microsoft.com/en-us/azure/private-link/disable-private-endpoint-network-policy) for Private Link Service on the control plane subnet
+1. [Disable network policies for Private Link Service](https://learn.microsoft.com/en-us/azure/private-link/disable-private-link-service-network-policy?tabs=private-link-network-policy-cli) on the control plane subnet
 
-    > This is required for the service to be able to connect to and manage the cluster.
+    > Optional. The ARO RP will disable this for you if you skip this step.
 
     ```bash
     az network vnet subnet update                                       \

--- a/content/docs/quickstart-aro.md
+++ b/content/docs/quickstart-aro.md
@@ -144,8 +144,7 @@ Create a virtual network with two empty subnets
       --resource-group $AZR_RESOURCE_GROUP \
       --vnet-name "$AZR_CLUSTER-aro-vnet-$AZR_RESOURCE_LOCATION" \
       --name "$AZR_CLUSTER-aro-control-subnet-$AZR_RESOURCE_LOCATION" \
-      --address-prefixes 10.0.0.0/23 \
-      --service-endpoints Microsoft.ContainerRegistry
+      --address-prefixes 10.0.0.0/23
     ```
 
 1. Create machine subnet
@@ -155,13 +154,12 @@ Create a virtual network with two empty subnets
       --resource-group $AZR_RESOURCE_GROUP \
       --vnet-name "$AZR_CLUSTER-aro-vnet-$AZR_RESOURCE_LOCATION" \
       --name "$AZR_CLUSTER-aro-machine-subnet-$AZR_RESOURCE_LOCATION" \
-      --address-prefixes 10.0.2.0/23 \
-      --service-endpoints Microsoft.ContainerRegistry
+      --address-prefixes 10.0.2.0/23
     ```
 
-1. Disable network policies on the control plane subnet
+1. [Disable network policies for Private Link Service](https://learn.microsoft.com/en-us/azure/private-link/disable-private-link-service-network-policy?tabs=private-link-network-policy-cli) on the control plane subnet
 
-    > This is required for the service to be able to connect to and manage the cluster.
+    > Optional. The ARO RP will disable this for you if you skip this step.
 
     ```bash
     az network vnet subnet update \


### PR DESCRIPTION
1. The dependency on service endpoints was removed back in June (see https://learn.microsoft.com/en-us/azure/openshift/azure-redhat-openshift-release-notes#version-412---august-2023).  This update removes service endpoints in our installation guides.

**Why does this matter**
Some customers have Azure policies that disallow Service Endpoints.  We don't want to give customers the impression that service endpoints are required in installation, if we don't actually use these anymore.

2. Disabling network policies on the private link service is now optional.  This update makes a note that if the customer chooses to skip this step, the ARO RP will automatically disable this for the customer.  Also - the link we provided is incorrect.  We are talking about private link network policies, *not* private endpoint network policies.  These are two separate attributes in an ARO subnet.