### PR TITLE
Update _index.md

### DIFF
--- a/content/docs/rosa/clf-cloudwatch-sts/_index.md
+++ b/content/docs/rosa/clf-cloudwatch-sts/_index.md
@@ -177,9 +177,8 @@ This guide shows how to deploy the Cluster Log Forwarder operator and configure 
    spec:
      collection:
        logs:
-          type: fluentd
+          type: vector
      forwarder:
-       fluentd: {}
      managementState: Managed
    EOF
    ```


### PR DESCRIPTION
Changed logging agent to vector from fluentd. Vector is now the default logging agent for logging operator version 5.6 and greater. Logging 5.6 is the oldest supported version