### PR TITLE
Rename all ROSA Private Link instances with PrivateLink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ The strategy here is to keep our taxonomy simple and helpful for traversing the 
 * Observability
 * OCP
 * OSD
-* Private Link
+* PrivateLink
 * Quickstarts
 * ROSA
 * STS

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,11 +12,11 @@ description: "Step-by-step tutorials from Red Hat experts to help you get the mo
 ### ROSA
 
 * [Prerequisites Checklist to Deploy ROSA Cluster with STS](/experts/rosa/prereq-list)
-* [Deploying ROSA in Private Link mode](/experts/rosa/private-link)
-  * [Add Public Ingress to Private Link Cluster](/experts/rosa/private-link/public-ingress)
+* [Deploying ROSA in PrivateLink mode](/experts/rosa/private-link)
+  * [Add Public Ingress to PrivateLink Cluster](/experts/rosa/private-link/public-ingress)
 * [Deploying ROSA PrivateLink Cluster with Ansible](/experts/rosa/ansible-rosa)
 * [Deploying ROSA in STS mode](/experts/rosa/sts)
-* [Deploying ROSA in STS mode with Private Link](/experts/rosa/sts-with-private-link)
+* [Deploying ROSA in STS mode with PrivateLink](/experts/rosa/sts-with-private-link)
 * [Deploying ROSA in STS mode with custom KMS Key](/experts/rosa/kms)
 * [Deploying ROSA via CRD and GitOps](/experts/rosa/rosa-gitops)
 * [Installing the AWS Load Balancer Operator on ROSA](/experts/rosa/aws-load-balancer-operator)

--- a/content/misc/references.md
+++ b/content/misc/references.md
@@ -21,7 +21,7 @@ title: Common Managed OpenShift References / Tasks
 ## Common Customer Topics
 
 ### Red Hat OpenShift on AWS - ROSA
-- [Creating a ROSA cluster with Private Link enabled](https://mobb.ninja/experts/rosa/private-link/)
+- [Creating a ROSA cluster with PrivateLink enabled](https://mobb.ninja/experts/rosa/private-link/)
 - [ROSA Installation Prerequisites](https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html)
 - [ROSA STS Workflow](https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-getting-started-workflow.html)
 - [Shared Responsiblity Matrix (who does what)](https://docs.openshift.com/rosa/rosa_policy/rosa-policy-responsibility-matrix.html)

--- a/content/rosa/private-link/_index.md
+++ b/content/rosa/private-link/_index.md
@@ -1,7 +1,7 @@
 ---
 date: '2021-06-11'
-title: Creating a ROSA cluster with Private Link enabled
-tags: ["AWS", "ROSA", "Private Link"]
+title: Creating a ROSA cluster with PrivateLink enabled
+tags: ["AWS", "ROSA", "PrivateLink"]
 ---
 ## Prerequisites
 
@@ -11,7 +11,7 @@ tags: ["AWS", "ROSA", "Private Link"]
 
 ## Create VPC and Subnets
 
-The following instructions use the AWS CLI to create the necessary networking to deploy a Private Link ROSA cluster into a Single AZ and are intended to be a guide. Ideally you would use an Automation tool like Ansible or Terraform to manage your VPCs.
+The following instructions use the AWS CLI to create the necessary networking to deploy a PrivateLink ROSA cluster into a Single AZ and are intended to be a guide. Ideally you would use an Automation tool like Ansible or Terraform to manage your VPCs.
 
 When creating subnets, make sure that subnet(s) are created to an availability zone that has ROSA instances types available. If AZ is not "forced", subnet is created to random AZ in the region. Force the AZ using `--availability-zone` argument in `create-subnet` command.
 

--- a/content/rosa/private-link/public-ingress.md
+++ b/content/rosa/private-link/public-ingress.md
@@ -1,7 +1,7 @@
 ---
 date: '2022-05-10'
-title: Adding a Public Ingress endpoint to a ROSA Private-Link Cluster
-tags: ["AWS", "ROSA", "Private Link"]
+title: Adding a Public Ingress endpoint to a ROSA PrivateLink Cluster
+tags: ["AWS", "ROSA", "PrivateLink"]
 authors:
   - Paul Czarkowski
   - Connor Wooley

--- a/content/rosa/sts-with-private-link/index.md
+++ b/content/rosa/sts-with-private-link/index.md
@@ -1,7 +1,7 @@
 ---
 date: '2021-08-09'
-title: Creating a ROSA cluster with Private Link enabled (custom VPC) and STS
-tags: ["AWS", "ROSA", "STS", "Private Link"]
+title: Creating a ROSA cluster with PrivateLink enabled (custom VPC) and STS
+tags: ["AWS", "ROSA", "STS", "PrivateLink"]
 authors:
   - Steve Mirman
   - Paul Czarkowski
@@ -293,7 +293,7 @@ This is a summary of the [official OpenShift docs](https://docs.openshift.com/ro
       --sts
     ```
 
-    > Confirm the Private Link set up
+    > Confirm the PrivateLink set up
     ![Route Table check output](./images/sts-pl8.png)
 
 1. Create the Operator Roles
@@ -324,7 +324,7 @@ This is a summary of the [official OpenShift docs](https://docs.openshift.com/ro
 
 ## Validate the cluster
 
-Once the cluster has finished installing it is time to validate. Validation when using Private Link requires the use of a **jump host**.
+Once the cluster has finished installing it is time to validate. Validation when using PrivateLink requires the use of a **jump host**.
 
  You can create them using the AWS Console or the AWS CLI as depicted below:
 

--- a/content/rosa/vpn/index.md
+++ b/content/rosa/vpn/index.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-07-28'
-title: Setup a VPN Connection into a Private Link ROSA Cluster with OpenVPN
+title: Setup a VPN Connection into a PrivateLink ROSA Cluster with OpenVPN
 tags: ["ROSA", "AWS"]
 authors:
   - Kevin Collins & Kumudu Herath

--- a/netlify.toml
+++ b/netlify.toml
@@ -62,3 +62,9 @@ from = "/experts/rosa/prereq-list/"
 to = "https://docs.openshift.com/rosa/rosa_tutorials/rosa-mobb-prerequisites-tutorial.html"
 status = 301
 force = true
+
+# Redirect old Private Link tag to new PrivateLink tag
+from = "/experts/tags/private-link/"
+to = "/experts/tags/privatelink/"
+status = 301
+force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -64,6 +64,7 @@ status = 301
 force = true
 
 # Redirect old Private Link tag to new PrivateLink tag
+[[redirects]]
 from = "/experts/tags/private-link/"
 to = "/experts/tags/privatelink/"
 status = 301


### PR DESCRIPTION
The term PrivateLink is an AWS product and should be used consistently in our documentation. I have renamed all of the instances of `Private Link` when referenced in ROSA/AWS documentation to `PrivateLink`.