### PR TITLE
fix: color contrast of code copy button

### DIFF
--- a/themes/rhds/assets/css/main.css
+++ b/themes/rhds/assets/css/main.css
@@ -415,7 +415,7 @@ rh-context-provider:is([color-palette="dark"], [color-palette="darker"], [color-
 
 .highlight pf-button::part(button) {
   --pf-icon--size: 14px;
-  color: var(--rh-color-text-secondary-on-dark, #c7c7c7);
+  color: var(--rh-color-icon-subtle, #707070);
 }
 
 .highlight pf-button:hover::part(button) {


### PR DESCRIPTION
### What I did

1. Corrected the rhds token usage for the code-block copy button on a light background.  Fixes accessibility issue in #446 


