### PR TITLE
Add pod security label on CSI driver for 4.13

### DIFF
--- a/content/misc/secrets-store-csi/hashicorp-vault.md
+++ b/content/misc/secrets-store-csi/hashicorp-vault.md
@@ -12,7 +12,7 @@ The HashiCorp Vault Secret CSI Driver allows you to access secrets stored in Has
 ## Prerequisites
 
 1. An OpenShift Cluster (ROSA, ARO, OSD, and OCP 4.x all work)
-1. kubectl
+1. oc
 1. helm v3
 
 {{< readfile file="/content/misc/secrets-store-csi/install-kubernetes-secret-store-driver.md" markdown="true" >}}
@@ -77,7 +77,7 @@ The HashiCorp Vault Secret CSI Driver allows you to access secrets stored in Has
     > Currently the CSI has a bug in its manifest which we need to patch
 
     ```bash
-    kubectl patch daemonset vault-csi-provider --type='json' \
+    oc patch daemonset vault-csi-provider --type='json' \
         -p='[{"op": "add", "path": "/spec/template/spec/containers/0/securityContext", "value": {"privileged": true} }]'
     ```
 
@@ -101,7 +101,7 @@ The HashiCorp Vault Secret CSI Driver allows you to access secrets stored in Has
     vault auth enable kubernetes
     ```
 
-1. Check your Cluster's token issuer
+1. Check your Cluster's token issuer in another terminal
 
     ```bash
     oc get authentication.config cluster \
@@ -151,7 +151,7 @@ The HashiCorp Vault Secret CSI Driver allows you to access secrets stored in Has
 1. Create a SecretProviderClass in the default namespace
 
     ```bash
-    cat <<EOF | kubectl apply -f -
+    cat <<EOF | oc apply -f -
     apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
     kind: SecretProviderClass
     metadata:
@@ -172,13 +172,13 @@ The HashiCorp Vault Secret CSI Driver allows you to access secrets stored in Has
 1. Create a service account `webapp-sa`
 
     ```bash
-    kubectl create serviceaccount -n default webapp-sa
+    oc create serviceaccount -n default webapp-sa
     ```
 
 1. Create a Pod to use the secret
 
     ```bash
-    cat << EOF | kubectl apply -f -
+    cat << EOF | oc apply -f -
     kind: Pod
     apiVersion: v1
     metadata:
@@ -206,7 +206,7 @@ The HashiCorp Vault Secret CSI Driver allows you to access secrets stored in Has
 1. Check the Pod has the secret
 
     ```bash
-    kubectl -n default exec webapp \
+    oc -n default exec webapp \
       -- cat /mnt/secrets-store/db-password
     ```
 
@@ -221,9 +221,9 @@ The HashiCorp Vault Secret CSI Driver allows you to access secrets stored in Has
 1. Delete the pod and
 
     ```bash
-    kubectl delete -n default pod webapp
-    kubectl delete -n default secretproviderclass vault-database
-    kubectl delete -n default serviceaccount webapp-sa
+    oc delete -n default pod webapp
+    oc delete -n default secretproviderclass vault-database
+    oc delete -n default serviceaccount webapp-sa
     ```
 
 1. Delete the Hashicorp Vault Helm

--- a/content/misc/secrets-store-csi/install-kubernetes-secret-store-driver.md
+++ b/content/misc/secrets-store-csi/install-kubernetes-secret-store-driver.md
@@ -48,3 +48,11 @@
     csi-secrets-store-secrets-store-csi-driver-cl7dv   3/3     Running   0          57s
     csi-secrets-store-secrets-store-csi-driver-gbz27   3/3     Running   0          57s
     ```
+
+1. Add pod security profile label for CSI Driver
+
+   {{% alert state="info" %}} This is required starting in OpenShift v4.13 {{% /alert %}}
+
+   ```bash
+   oc label csidriver/secrets-store.csi.k8s.io security.openshift.io/csi-ephemeral-volume-profile=restricted
+   ```

--- a/content/rosa/aws-secrets-manager-csi/index.md
+++ b/content/rosa/aws-secrets-manager-csi/index.md
@@ -91,6 +91,14 @@ This is made even easier and more secure through the use of AWS STS and Kubernet
       csi-secrets-store-driver-secrets-store-csi-driver
     ```
 
+1. Add pod security profile label for CSI Driver 
+
+   {{% alert state="info" %}} This is required starting in OpenShift v4.13 {{% /alert %}}
+
+   ```bash
+   oc label csidriver/secrets-store.csi.k8s.io security.openshift.io/csi-ephemeral-volume-profile=restricted
+   ```
+
 ## Creating a Secret and IAM Access Policies
 
 1. Create a secret in Secrets Manager


### PR DESCRIPTION
Changes:

- Add label `security.openshift.io/csi-ephemeral-volume-profile: restricted` on CSI Driver API object for 4.13
- Update Vault instructions to consistently use `oc`. (currently mixes `kubectl` and `oc`)
- Clarify Vault instructions to check the Service Account Issuer in another terminal, outside the vault session

Tested this on ARO v4.12 and ROSA v4.13.  Adding the label does not break previous versions.