### PR TITLE
Adds site experience to Page Load Started.

### DIFF
--- a/themes/rhds/layouts/partials/eddl/page-load-started.html
+++ b/themes/rhds/layouts/partials/eddl/page-load-started.html
@@ -46,7 +46,7 @@
       pageType: '',
       pageSubType: '',
       pageStatus: '',
-      siteExperience: '',
+      siteExperience: (window.innerWidth > 992) ? "desktop": (window.innerWidth > 768 ? "tablet" : "mobile"),
       siteLanguage: '{{ or site.Language.LanguageCode site.Language.Lang }}',
       subsection: (subsections[2]) ? subsections[2]: '',
       subsection2: (subsections[3]) ? subsections[3]: '',


### PR DESCRIPTION
Issue:
- Page Load Started is not tracking view size for analytics.

Change:
- Enhancement to Page Load Started event allows us to get a rough idea of the browser window size.

See `siteExperience` in [EDDL Spec](https://github.com/searchdiscovery/redhat-datalayer/blob/main/EDDL/global-datalayer.md#variable-definitions-13)