### PR TITLE
fix: for aro version 4.12

### DIFF
--- a/content/aro/blob-storage-csi/index.md
+++ b/content/aro/blob-storage-csi/index.md
@@ -140,6 +140,7 @@ Now, we need to install the driver, which could be done using a helm chart. This
       - 'system:masters'
     volumes:
       - '*'
+    allowHostPID: true
     allowHostNetwork: true    
     EOF
     ```


### PR DESCRIPTION
This guide has been working well with ARO 4.11, but it is not with 4.12. This fix is already tested in version 4.11 and 4.12, and it works like a charm. 