### PR TITLE
Minor clarity changes around UserDefinedNetworks

### DIFF
--- a/content/aro/private-cluster.md
+++ b/content/aro/private-cluster.md
@@ -183,13 +183,13 @@ Create a virtual network with two empty subnets
 
 Public and Private clusters will have [--outbound-type](https://learn.microsoft.com/en-us/cli/azure/aro?view=azure-cli-latest#az-aro-create) defined to LoadBalancer by default. It means all clusters by default have open egress to the internet through the public load balancer.  
 
-To change the default behavior and restrict the Internet Egress, you have to set `--outbound-type` during the creation of the cluster to `UserDefinedRouting` and use a Firewall solution of your choice or even Azure native solutions like Azure Firewall or Azure NAT Gateway.
+To change the default behavior and restrict the Internet Egress you have to set `--outbound-type` to `UserDefinedRouting` during cluster creation, and set up a traffic to run through a Firewall solution. This can either be a 3rd party solution or a native Azure solution such as Azure Firewall/Azure NAT Gateway.
 
-If you want to proceed with the `UserDefinedRouting`, **choose either** NAT gateway **or** Firewall + Internet Egress:
+If you want to proceed with the `UserDefinedRouting` the two examples below show how this can be achieved through either Azure NAT gateway **or** Azure Firewall + Internet Egress.
 
 #### 1a. NAT Gateway
 
-This replaces the routes for the cluster to go through the Azure NAT GW service for egress vs the LoadBalancer. It does come with extra Azure costs of course.
+This option replaces the routes for the cluster to go through the Azure NAT GW service for egress vs the LoadBalancer. This will incur extra Azure costs.
 
 {{% alert state="info" %}}You can skip this step if you don't need to restrict egress.{{% /alert %}}
 
@@ -240,7 +240,7 @@ This replaces the routes for the cluster to go through the Azure NAT GW service 
 
 #### 1b. Firewall + Internet Egress
 
-This replaces the routes for the cluster to go through the Firewall for egress vs the LoadBalancer. It does come with extra Azure costs of course.
+This option replaces the routes for the cluster to go through Azure Firewall for egress traffic, rather than the LoadBalancer. This will incur extra Azure costs.
 
 {{% alert state="info" %}}You can skip this step if you don't need to restrict egress.{{% /alert %}}
 

--- a/content/aro/private-cluster.md
+++ b/content/aro/private-cluster.md
@@ -183,11 +183,11 @@ Create a virtual network with two empty subnets
 
 Public and Private clusters will have [--outbound-type](https://learn.microsoft.com/en-us/cli/azure/aro?view=azure-cli-latest#az-aro-create) defined to LoadBalancer by default. It means all clusters by default have open egress to the internet through the public load balancer.  
 
-If you want to change the default behavior to restrict the Internet Egress, you have to set --outbound-type during the creation of the cluster to UserDefinedRouting and use a Firewall solution from your choice or even Azure native solutions like Azure Firewall or Azure NAT Gateway.
+To change the default behavior and restrict the Internet Egress, you have to set `--outbound-type` during the creation of the cluster to `UserDefinedRouting` and use a Firewall solution of your choice or even Azure native solutions like Azure Firewall or Azure NAT Gateway.
 
-If you want to proceed with the UserDefinedRouting option for the Internet Egress, run through the step of one of the two following options
+If you want to proceed with the `UserDefinedRouting`, **choose either** NAT gateway **or** Firewall + Internet Egress:
 
-#### Nat GW
+#### 1a. NAT Gateway
 
 This replaces the routes for the cluster to go through the Azure NAT GW service for egress vs the LoadBalancer. It does come with extra Azure costs of course.
 
@@ -238,8 +238,7 @@ This replaces the routes for the cluster to go through the Azure NAT GW service 
       --nat-gateway "${AZR_CLUSTER}-natgw"
     ```
 
-
-#### Firewall + Internet Egress
+#### 1b. Firewall + Internet Egress
 
 This replaces the routes for the cluster to go through the Firewall for egress vs the LoadBalancer. It does come with extra Azure costs of course.
 
@@ -370,6 +369,7 @@ az aro create                                                            \
 --client-secret "${AZ_SP_PASS}"
  ```
 
+{{% alert state="info" %}} Be sure to add the `--outbound-type UserDefinedRouting` flag if you are not using the default routing.{{% /alert %}}
 
 ### Jump Host
 
@@ -443,8 +443,6 @@ With the cluster in a private network, we can create a Jump host in order to con
     ```bash
     oc login $APISERVER --username kubeadmin --password ${ADMINPW}
     ```
-
-
 
 ### Delete Cluster
 


### PR DESCRIPTION
Made some minor changes around user defined networks.

Note based on the fact you all said:

`If you want to change the default behavior to restrict the Internet Egress, you have to set --outbound-type during the creation of the cluster to UserDefinedRouting`

That my alert below is true, but I have not actually run the create command so correct me if I am wrong

```
{{% alert state="info" %}} Be sure to add the `--outbound-type UserDefinedRouting` flag if you are not using the default routing.{{% /alert %}}
```