### PR TITLE
Fix quoting on Front Door validation token

### DIFF
--- a/content/aro/frontdoor/index.md
+++ b/content/aro/frontdoor/index.md
@@ -226,7 +226,8 @@ After we have the cluster up and running, we need to create a private link servi
    --resource-group $ARORG \
    --profile-name $AFD_NAME \
    --custom-domain-name $AFD_MINE_CUSTOM_DOMAIN_NAME \
-   --query "validationProperties.validationToken")
+   --query "validationProperties.validationToken"
+   -o tsv)
    ```
 
 1. Create a DNS Zone


### PR DESCRIPTION
Fix bug where the Front Door validation token got wrapped in a set of quotation marks, causing domain validation to fail. When using az with --query for a single field, that field still has JSON representation by default, and in this case, that means it is quoted because it is a string. If the TXT record contains a value that has an extra pair of quotes, domain validation will never move on from the Pending state.

Switching to a tsv representation causes az to return the value without quotes.