### PR TITLE
Update the MOBB helm repo link

### DIFF
--- a/content/o11y/ocp-grafana/index.md
+++ b/content/o11y/ocp-grafana/index.md
@@ -57,7 +57,7 @@ Since OpenShift uses Prometheus for both Cluster and User Workload metrics, its 
 1. Add the Managed OpenShift Black Belt helm repo
 
     ```bash
-    helm repo add mobb https://mobb.github.io/helm-charts
+    helm repo add mobb https://rh-mobb.github.io/helm-charts/
     ```
 
 1. Deploy Grafana


### PR DESCRIPTION
The link of mobb helm repo has been out-dated,

```
$ helm repo add mobb https://mobb.github.io/helm-charts
Error: looks like "https://mobb.github.io/helm-charts" is not a valid chart repository or cannot be reached: failed to fetch https://mobb.github.io/helm-charts/index.yaml : 404 Not Found
```

this works 

```
$ helm repo add mobb https://rh-mobb.github.io/helm-charts/                                                                                                                                                                                  
"mobb" has been added to your repositories
```