### PR TITLE
Update gitops page to avoid publishing todo item

### DIFF
--- a/content/redhat/gitops/index.md
+++ b/content/redhat/gitops/index.md
@@ -162,8 +162,6 @@ Login to the CLI:
 2. Refresh the bgd application window and notice the change in box color<br>
     ![screenshot of app_blue](./app_blue.png)
 
-### Details from GitHub perspective
-TBD
 
 
 


### PR DESCRIPTION
Can be added back when content is available