### PR TITLE
Fix bugs in Arc instructions

### DIFF
--- a/content/aro/azure-arc-integration/index.md
+++ b/content/aro/azure-arc-integration/index.md
@@ -161,7 +161,7 @@ oc apply -f azure-arc-secret.yaml
 ```
 
 ```bash
-TOKEN=$(oc get secret azure-arc-observability-secret -o jsonpath='{$.data.token}' | base64 -d | sed 's/$/\\n/g')
+TOKEN=$(oc get secret azure-arc-observability-secret -o jsonpath='{$.data.token}' | base64 -d ; echo)
 echo $TOKEN
 ```
 

--- a/content/aro/azure-arc-integration/index.md
+++ b/content/aro/azure-arc-integration/index.md
@@ -59,7 +59,7 @@ oc login $apiServer -u kubeadmin -p $kubeadmin_password
 
 Run the following command:
 ```bash
-az connectedk8s connect --resource-group $resourceGroupName --name $clusterName --distribution openshift --infrastructure auto
+az connectedk8s connect --resource-group $resourceGroupName --name $clusterName --distribution openshift
 ```
 
 After running the commnad. grant the following permissions and restart kube-aad-proxy pod

--- a/content/aro/azure-arc-integration/index.md
+++ b/content/aro/azure-arc-integration/index.md
@@ -67,7 +67,7 @@ After running the commnad. grant the following permissions and restart kube-aad-
 oc project azure-arc
 oc adm policy add-scc-to-user privileged system:serviceaccount:azure-arc:azure-arc-kube-aad-proxy-sa
 
-oc get pod | grep
+oc get pod | grep kube-aad-proxy
 kube-aad-proxy-6d9b66b9cd-g27xr              0/2     ContainerCreating   0          26s
 
 oc delete pod kube-aad-proxy-6d9b66b9cd-g27xr


### PR DESCRIPTION
For Key Vault, Add the missing steps to create a service principal, capture its creds, and set a policy so that the service principal can get secrets from the vault. Add a command so that people know how to find their tenant ID.

When enabling observability, fix a bug where the token was getting a backslash-n applied to it.

Fix grep command to find named pods.

Remove `--infrastructure="auto"` since this is no longer supported.