### PR TITLE
Fix description of addon config step

### DIFF
--- a/content/aro/acm-odf-aro/index.md
+++ b/content/aro/acm-odf-aro/index.md
@@ -730,7 +730,7 @@ Since this cluster will reside in a different virtual network, we should create 
     EOF
     ```
 
-3. Create add config for Submariner
+3. Create addon config for cluster
 
     ```sh
     cat << EOF | oc apply -f -
@@ -801,7 +801,7 @@ Since this cluster will reside in a different virtual network, we should create 
     EOF
     ```
 
-3. Create add config for Submariner
+3. Create addon config for cluster
 
     ```
     cat << EOF | oc apply -f -


### PR DESCRIPTION
The addon config has nothing to do with Submariner and is instead needed to enable ACM agent capabilities on the cluster.

Fix its description so that if someone is following these instructions without the intent to use Submariner, theyu still follow this step.