### PR TITLE
Adding steps for patch operator install

### DIFF
--- a/content/aro/shipping-logs-and-metrics-to-azure-blob/index.md
+++ b/content/aro/shipping-logs-and-metrics-to-azure-blob/index.md
@@ -270,7 +270,7 @@ Next we can configure Metrics Federation to Azure Blob Storage. This is done by 
 
     ```bash
     helm upgrade -n patch-operator patch-operator --create-namespace \
-      mobb/operatorhub --version 0.1.2 --install \
+      mobb/operatorhub --install \
       --values https://raw.githubusercontent.com/rh-mobb/helm-charts/main/charts/aro-thanos-af/files/patch-operator.yaml
     ```
 

--- a/content/aro/shipping-logs-and-metrics-to-azure-blob/index.md
+++ b/content/aro/shipping-logs-and-metrics-to-azure-blob/index.md
@@ -264,6 +264,22 @@ Next we can configure Metrics Federation to Azure Blob Storage. This is done by 
    No resources found in mobb-aro-obs namespace.
    ```
 
+### Deploy OpenShift Path Operator
+
+1. Use Helm deploy the OpenShift Patch Operator
+
+    ```bash
+    helm upgrade -n patch-operator patch-operator --create-namespace \
+      mobb/operatorhub --version 0.1.2 --install \
+      --values https://raw.githubusercontent.com/rh-mobb/helm-charts/main/charts/aro-thanos-af/files/patch-operator.yaml
+    ```
+
+1. Wait for the Operator to be ready
+
+    ```bash
+    oc rollout status -n patch-operator \
+      deployment/patch-operator-controller-manager
+
 ### Configure Metrics Federation
 
 1. Deploy `mobb/aro-thanos-af` Helm Chart to configure metrics federation


### PR DESCRIPTION
With the release versions removed from the [previous docs commit](https://github.com/rh-mobb/documentation/commit/9d905589a81b59eaba2993e741b8893f3f222f80#diff-399fb8f81b390ee72992f1e682c723e23405eebe6bd4ae6088c3dbbc4d1f3574), the patch operator needs to be installed to process the aro-thanos-af helm chart. Otherwise, it will throw the error below.

```
ensure CRDs are installed first, resource mapping not found for name: "cluster-monitoring-config-patcher" namespace: "patch-operator" from "": no matches for kind "Patch" in version "redhatcop.redhat.io/v1alpha1"
ensure CRDs are installed first, resource mapping not found for name: "user-workload-monitoring-config-patcher" namespace: "patch-operator" from "": no matches for kind "Patch" in version "redhatcop.redhat.io/v1alpha1"
ensure CRDs are installed first]
```

[Updated aro-thanos-af change using patch operator](https://github.com/rh-mobb/helm-charts/commit/ae42adba65e1d14b0c0c2061a362017842bec60c#diff-b6ad351f4c6b2a1b01a9d211605a88ca3fa1b37e646692f1b436bb3a0c4941c2R88-R136)
