### PR TITLE
Remove "Enable log aggregation" for now

### DIFF
--- a/content/aro/azure-arc-integration/index.md
+++ b/content/aro/azure-arc-integration/index.md
@@ -369,24 +369,6 @@ oc exec secret-store-pod -- cat /mnt/secrets-store/DemoSecret
 MyExampleSecret
 ```
 
-
-## Enable log aggregation
-In order to collect logs from ARO cluster and store it in Azure ARC. configure azure monitor
-
-Create Azure Log Analytics Workspace
-```
-az monitor log-analytics workspace create --resource-group <<same as above>> --workspace-name loganalyticsworkspace
-```
-Goto Azure ARC portal and click on ```logs```
-
-![Image](Images/aro-arc-integration-image2.png)
-
-Click on ```configure azure monitor``` button and select the workspace created in last step and click on configure.
-
-![Image](Images/aro-arc-integration-image3.png)
-
-Now you can go see logs and metrics for your cluster.
-
 ## Monitor ARO cluster against Goverance Policies
 Azure Policy extends Gatekeeper v3, an admission controller webhook for Open Policy Agent (OPA), to apply at-scale enforcements and safeguards on your clusters in a centralized, consistent manner. Azure Policy makes it possible to manage and report on the compliance state of your Kubernetes clusters from one place. The add-on enacts the following functions:
 - Checks with Azure Policy service for policy assignments to the cluster.


### PR DESCRIPTION
This section is incorrect in several ways:

- It talks about log aggregation but attempts to install the metrics extension
- The extension azuremonitor-metrics currently requires a workaround to use on OpenShift versions 4.13 and above https://access.redhat.com/solutions/7064794
- The extension azuremonitor-metrics is currently not supported by Microsoft on OpenShift per https://learn.microsoft.com/en-us/azure/azure-monitor/containers/kubernetes-monitoring-enable

We can eventually rewrite these to properly instruct on azuremonitor-containers, which is actually how log aggregation works, but for now it's better to prevent anyone from being misled by incorrect instructions.

This gets us part way to #526 