### PR TITLE
Reverting back the note around the retention

### DIFF
--- a/content/aro/federated-metrics/index.md
+++ b/content/aro/federated-metrics/index.md
@@ -103,10 +103,7 @@ This guide shows how to set up Thanos to federate both System and User Workload 
 1. Deploy ARO Thanos Azure Blob container Helm Chart (mobb/aro-thanos-af)
 
     **> Note: `enableUserWorkloadMetrics=true` will overwrite configs for cluster and userworkload metrics. If you have customized them already, you may need to modify `patch-monitoring-configs.yaml` in the Helm chart to include your changes.
-   
-   **> Note: If you do not explicitly define values for either retention or retentionSize, retention time defaults to 15 days for core platform monitoring and 24 hours for user-defined project monitoring. For specifying the retention time you need to modify the `patch-monitoring-configs.yaml` with the relevant retention parameters following [Modifying the retention time and size for Prometheus metrics data](https://docs.openshift.com/container-platform/4.14/observability/monitoring/configuring-the-monitoring-stack.html#modifying-retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack))
-
-
+     
     ```bash
     helm upgrade -n $NAMESPACE aro-thanos-af \
       --install mobb/aro-thanos-af \


### PR DESCRIPTION
The retention rules aren't applicable for the remote write storage, further configuration on Thanos end is needed to control the retention of metrics in the Azure Blob side.