### PR TITLE
Small Cloud NGFW Improvements

### DIFF
--- a/content/gcp/cloud-ngfw/index.md
+++ b/content/gcp/cloud-ngfw/index.md
@@ -167,13 +167,13 @@ OpenShift Dedicated relies on the Service Usage API (`serviceusage.googleapis.co
 1. Create a blanket allow rule for east/west and intra-cluster traffic by running the following command:
     ```bash
     gcloud compute network-firewall-policies rules create 500 \
-        --description "Allow east/west and intra-cluster connectivity" \
+        --description "Allow egress to private IP ranges" \
         --action=allow \
         --firewall-policy=${prefix} \
         --global-firewall-policy \
         --direction=EGRESS \
         --layer4-configs all \
-        --dest-ip-ranges=${service_cidr},${machine_cidr},${pod_cidr}
+        --dest-ip-ranges=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
     ```
 
 1. Create an allow rule for HTTPS (`tcp/443`) domains required for OpenShift Dedicated by running the following command:

--- a/content/gcp/cloud-ngfw/index.md
+++ b/content/gcp/cloud-ngfw/index.md
@@ -114,7 +114,7 @@ Before we can deploy a Cloud NGFW, we must first create a VPC and subnets that w
         --nat-external-ip-pool=${prefix}-${region}-cloudnatip
     ```
 
-### Create private DNS records for Google Private Access
+### Create private DNS records for Private Google Access
 
 1. Create a private DNS zone for the `googleapis.com` domain by running the following command:
     ```bash
@@ -153,7 +153,7 @@ Before we can deploy a Cloud NGFW, we must first create a VPC and subnets that w
         --ttl=300
     ```
     {{% alert state="info" %}}
-OpenShift Dedicated relies on the Service Usage API (`serviceusage.googleapis.com`) which is [not provided by the Google Private Access restricted VIP](https://cloud.google.com/vpc-service-controls/docs/restricted-vip-services). To circumvent this, we expose the Service Usage API using the [Google Private Access private VIP](https://cloud.google.com/vpc/docs/configure-private-google-access#domain-options). This is the only service exposed by the Google Private Access private VIP in this tutorial. 
+OpenShift Dedicated relies on the Service Usage API (`serviceusage.googleapis.com`) which is [not provided by the Private Google Access restricted VIP](https://cloud.google.com/vpc-service-controls/docs/restricted-vip-services). To circumvent this, we expose the Service Usage API using the [Private Google Access private VIP](https://cloud.google.com/vpc/docs/configure-private-google-access#domain-options). This is the only service exposed by the Private Google Access private VIP in this tutorial. 
 {{% /alert %}}
 
 1. Apply the staged record set transaction you started above by running the following command:
@@ -202,7 +202,7 @@ OpenShift Dedicated relies on the Service Usage API (`serviceusage.googleapis.co
     ```
     > These domains are sourced from internal documentation. These domains will be published in general documentation when the Private Service Connect feature is released. 
 
-1. Create an allow rule for Google Private Access endpoints by running the following command:
+1. Create an allow rule for Private Google Access endpoints by running the following command:
     ```bash
     gcloud compute network-firewall-policies rules create 602 \
         --description "Allow egress to Google APIs via Private Google Access" \

--- a/content/gcp/cloud-ngfw/index.md
+++ b/content/gcp/cloud-ngfw/index.md
@@ -164,7 +164,7 @@ OpenShift Dedicated relies on the Service Usage API (`serviceusage.googleapis.co
 
 ### Create the Firewall Rules
 
-1. Create a blanket allow rule for east/west and intra-cluster traffic by running the following command:
+1. Create a blanket allow rule for private IP (RFC 1918) address space by running the following command:
     ```bash
     gcloud compute network-firewall-policies rules create 500 \
         --description "Allow egress to private IP ranges" \
@@ -198,7 +198,7 @@ OpenShift Dedicated relies on the Service Usage API (`serviceusage.googleapis.co
         --global-firewall-policy \
         --direction=EGRESS \
         --layer4-configs tcp:9997 \
-        --dest-fqdns inputs1.osdsecuritylogs.splunkcloud.com,inputs2.osdsecuritylogs.splunkcloud.com,inputs4.osdsecuritylogs.splunkcloud.com,inputs5.osdsecuritylogs.splunkcloud.com,inputs6.osdsecuritylogs.splunkcloud.com,inputs7.osdsecuritylogs.splunkcloud.com,inputs8.osdsecuritylogs.splunkcloud.com,inputs9.osdsecuritylogs.splunkcloud.com,inputs10.osdsecuritylogs.splunkcloud.com,inputs11.osdsecuritylogs.splunkcloud.com,inputs12.osdsecuritylogs.splunkcloud.com,inputs13.osdsecuritylogs.splunkcloud.com,inputs14.osdsecuritylogs.splunkcloud.com,inputs15.osdsecuritylogs.splunkcloud.com
+        --dest-fqdns inputs1.osdsecuritylogs.splunkcloud.com,inputs2.osdsecuritylogs.splunkcloud.com,inputs3.osdsecuritylogs.splunkcloud.com,inputs4.osdsecuritylogs.splunkcloud.com,inputs5.osdsecuritylogs.splunkcloud.com,inputs6.osdsecuritylogs.splunkcloud.com,inputs7.osdsecuritylogs.splunkcloud.com,inputs8.osdsecuritylogs.splunkcloud.com,inputs9.osdsecuritylogs.splunkcloud.com,inputs10.osdsecuritylogs.splunkcloud.com,inputs11.osdsecuritylogs.splunkcloud.com,inputs12.osdsecuritylogs.splunkcloud.com,inputs13.osdsecuritylogs.splunkcloud.com,inputs14.osdsecuritylogs.splunkcloud.com,inputs15.osdsecuritylogs.splunkcloud.com
     ```
     > These domains are sourced from internal documentation. These domains will be published in general documentation when the Private Service Connect feature is released. 
 


### PR DESCRIPTION
- Changing to allowing egress to all RFC 1918 addresses
- Correction "Private Google Access" language
- Adds missing `inputs3.osdsecuritylogs.splunkcloud.com` endpoint