### PR TITLE
fix: keyboard nav order of codeblocks

### DIFF
--- a/themes/rhds/assets/css/main.css
+++ b/themes/rhds/assets/css/main.css
@@ -327,7 +327,7 @@ main {
   font-size: var(--rh-font-size-body-text-sm, 0.875rem);
   padding: var(--rh-space-lg, 16px) 0;
 
-  &:not(:last-of-type):after {
+  .breadcrumb:not(:last-of-type):after {
     content: url(/experts/images/breadcrumb-spacer.svg);
     width: 11px;
     height: 11px;

--- a/themes/rhds/assets/css/main.css
+++ b/themes/rhds/assets/css/main.css
@@ -470,7 +470,8 @@ rh-surface:is([color-palette="dark"], [color-palette="darker"], [color-palette="
   
   & > pf-tooltip {
     position: absolute;
-    right: 0;
+    inset-block: 0;
+    inset-inline-end: 0;
   }
 
   & code {

--- a/themes/rhds/assets/js/main.js
+++ b/themes/rhds/assets/js/main.js
@@ -23,9 +23,9 @@ codeBlocks.forEach(function (block) {
   const pre = block.parentNode;
   if (pre.parentNode.classList.contains('highlight')) {
     const highlight = pre.parentNode;
-    highlight.insertBefore(pfTooltip, pre);
+    highlight.append(pfTooltip);
   } else {
-    pre.parentNode.insertBefore(pfTooltip, pre);
+    pre.append(pfTooltip);
   }
 
   const sleep = (ms) => new Promise(r => setTimeout(r, ms));

--- a/themes/rhds/layouts/partials/head/importmap.html
+++ b/themes/rhds/layouts/partials/head/importmap.html
@@ -48,5 +48,5 @@
     }
   }
   </script>
-  <script async src="https://www.redhatstatic.com/dx/v1-alpha/es-module-shims@1.7.3/dist/es-module-shims.js" crossorigin="anonymous"></script>
+  <script async src="https://www.redhatstatic.com/dx/v1-alpha/es-module-shims@1.7.3.js" crossorigin="anonymous"></script>
 {{- end }}


### PR DESCRIPTION
## What I did

- fix order of keyboard nav for codeblocks, on tab: code first -> copy button
- corrected production cdn url for es-shims