### PR TITLE
group and prune parameters are missing an indentation

### DIFF
--- a/content/idp/az-ad-grp-sync/index.md
+++ b/content/idp/az-ad-grp-sync/index.md
@@ -91,11 +91,11 @@ The GroupSync job requires permissions on the Azure AD tenant beyond those of th
                 credentialsSecret:
                   name: azure-group-sync
                   namespace: group-sync-operator
-              groups:
-                - rosa_admin
-                - rosa_project_owner
-                - rosa_viewer
-              prune: false
+                  groups:
+                    - rosa_admin
+                    - rosa_project_owner
+                    - rosa_viewer
+                  prune: false
         schedule: '* * * * *'
     ```
 

--- a/content/idp/az-ad-grp-sync/index.md
+++ b/content/idp/az-ad-grp-sync/index.md
@@ -91,11 +91,11 @@ The GroupSync job requires permissions on the Azure AD tenant beyond those of th
                 credentialsSecret:
                   name: azure-group-sync
                   namespace: group-sync-operator
-                  groups:
-                    - rosa_admin
-                    - rosa_project_owner
-                    - rosa_viewer
-                  prune: false
+                groups:
+                  - rosa_admin
+                  - rosa_project_owner
+                  - rosa_viewer
+                prune: false
         schedule: '* * * * *'
     ```
 


### PR DESCRIPTION
The group and prune parameters are missing an indentation, since as explained on the GroupSync resource, the groups and prune parameters are fields for the azure setting.

```
$ oc explain groupsyncs.spec.providers.azure 
GROUP:      redhatcop.redhat.io
KIND:       GroupSync
VERSION:    v1alpha1

FIELD: azure <Object>

DESCRIPTION:
    Azure represents the Azure provider
    
FIELDS:
...
  groups        <[]string>
    Groups represents a filtered list of groups to synchronize
...

  prune <boolean>
    Prune Whether to prune groups that are no longer in Azure. Default is false
```

Meaning that these values should be at the same indentation level as credentialsSecret, and in the MOBB document, they appear at the same indentation level as azure, this causes an Admission Webhook Warning

```
Admission Webhook Warning
GroupSync azure-groupsync violates policy 299 - "unknown field \"spec.providers[0].groups\"", 299 - "unknown field \"spec.providers[0].prune\""
```