### PR TITLE
Removed extra spaces in commands

### DIFF
--- a/content/rosa/vpn/index.md
+++ b/content/rosa/vpn/index.md
@@ -105,7 +105,7 @@ There are many ways and methods to create certificates for VPN, the guide below 
     ```bash
    SERVER_CERT_ARN=$(aws acm import-certificate \
    --certificate fileb://issued/server.crt \
-   --private-key fileb://private/server.key \ 
+   --private-key fileb://private/server.key \
    --certificate-chain fileb://ca.crt \
    --region $REGION \
    --query CertificateArn \
@@ -115,12 +115,12 @@ There are many ways and methods to create certificates for VPN, the guide below 
 1. Import the client certificate
 
      ```bash
-     CLIENT_CERT_ARN=$(aws acm import-certificate  \ 
+     CLIENT_CERT_ARN=$(aws acm import-certificate \
      --certificate fileb://issued/aws.crt \
      --private-key fileb://private/aws.key \
      --certificate-chain fileb://ca.crt \
      --region $REGION \
-     --query CertificateArn \ 
+     --query CertificateArn \
      --output text)
     ```
 


### PR DESCRIPTION
Extra spaces in the import certificate commands have been removed, it causes an issue with the CLI command.