### PR TITLE
Correct VTI instructions

### DIFF
--- a/content/rosa/s2s-vpn/index.md
+++ b/content/rosa/s2s-vpn/index.md
@@ -504,8 +504,6 @@ Inside IP Addresses
 ...
 ```
 
-In the AWS console, go to **VPC**,
-
 ```bash
 sudo tee /etc/ipsec.conf >/dev/null <<'EOF'
 config setup


### PR DESCRIPTION
Fix ike and esp parameters to match what AWS is actually expecting and prevent "authentication failed: peer authentication requires policy RSASIG_v1_5" errors.

Add more comments about what to put in various fields.

Add a section on how to find the customer gateway inside IP, it is unfortunately not super obvious from the AWS console.