### PR TITLE
fix: private subnets in ROSA HCP can not be identified by tags

### DIFF
--- a/content/aro/terraform-install/index.md
+++ b/content/aro/terraform-install/index.md
@@ -1,5 +1,5 @@
 ---
-date: '2023-2-10'
+date: '2023-02-10'
 title: Deploying ARO using azurerm Terraform Provider
 tags: ["azure", "ARO", "Terraform"]
 authors:


### PR DESCRIPTION
Fix: The guideline doesn't work for HCP since the private subnets are identified by their tags. That works only for Classic.