### PR TITLE
Update CloudWatch Agent guide for OpenShift 4.20 validation

### DIFF
--- a/content/rosa/metrics-to-cloudwatch-agent/index.md
+++ b/content/rosa/metrics-to-cloudwatch-agent/index.md
@@ -5,6 +5,7 @@ tags: ["ROSA"]
 authors:
   - Kevin Collins
   - Michael McNeill
+validated_version: "4.20"
 ---
 This document shows how you can use the AWS CloudWatch Agent to scrape Prometheus endpoints and publish metrics to CloudWatch in a Red Hat OpenShift Service on AWS (ROSA) cluster.
 
@@ -25,7 +26,8 @@ Currently the AWS CloudWatch Agent [does not support](https://github.com/aws/ama
 
 1. Configure the following environment variables:
    ```bash
-   export ROSA_CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
+   export CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.apiServerURL}" | awk -F '.' '{print $2}')
+   export ROSA_CLUSTER_NAME=${CLUSTER_NAME}
    export REGION=$(rosa describe cluster -c ${ROSA_CLUSTER_NAME} --output json | jq -r .region.id)
    export OIDC_ENDPOINT=$(oc get authentication.config.openshift.io cluster -o json | jq -r .spec.serviceAccountIssuer | sed 's|^https://||')
    export AWS_ACCOUNT_ID=`aws sts get-caller-identity --query Account --output text`
@@ -319,7 +321,7 @@ Currently the AWS CloudWatch Agent [does not support](https://github.com/aws/ama
 1. Download the Sample Dashboard
 
    ```bash
-   wget -O ${SCRATCH}/dashboard.json https://raw.githubusercontent.com/rh-mobb/documentation/main/content/rosa/metrics-to-cloudwatch-agent/dashboard.json
+   curl -L -o ${SCRATCH}/dashboard.json https://raw.githubusercontent.com/rh-mobb/documentation/main/content/rosa/metrics-to-cloudwatch-agent/dashboard.json
    ```
 
 1. Update the Sample Dashboard

--- a/content/rosa/metrics-to-cloudwatch-agent/index.md
+++ b/content/rosa/metrics-to-cloudwatch-agent/index.md
@@ -26,8 +26,7 @@ Currently the AWS CloudWatch Agent [does not support](https://github.com/aws/ama
 
 1. Configure the following environment variables:
    ```bash
-   export CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.apiServerURL}" | awk -F '.' '{print $2}')
-   export ROSA_CLUSTER_NAME=${CLUSTER_NAME}
+   export ROSA_CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.apiServerURL}" | awk -F '.' '{print $2}')
    export REGION=$(rosa describe cluster -c ${ROSA_CLUSTER_NAME} --output json | jq -r .region.id)
    export OIDC_ENDPOINT=$(oc get authentication.config.openshift.io cluster -o json | jq -r .spec.serviceAccountIssuer | sed 's|^https://||')
    export AWS_ACCOUNT_ID=`aws sts get-caller-identity --query Account --output text`


### PR DESCRIPTION
## Summary

Updates the CloudWatch Agent documentation to address issue #802:
- Adds `validated_version: "4.20"` to front matter, which automatically displays the validation banner
- Updates cluster name extraction method to use `apiServerURL` for improved reliability
- Replaces `wget` with `curl -L -o` for dashboard download

## Changes

1. **Validation banner**: Added `validated_version: "4.20"` to front matter per CONTRIBUTING.md guidelines
2. **Cluster name extraction**: Changed from parsing `infrastructureName` to extracting from `apiServerURL` using awk
3. **Download command**: Replaced `wget -O` with `curl -L -o` for better compatibility

## Test plan

- [x] Validated commands on OpenShift 4.20 cluster
- [x] Verified front matter follows CONTRIBUTING.md format
- [ ] Preview rendered page to confirm validation banner appears correctly

Fixes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)