### PR TITLE
added publish resources label to custom kms article

### DIFF
--- a/content/rosa/kms/index.md
+++ b/content/rosa/kms/index.md
@@ -1,4 +1,8 @@
 ---
+build:
+  list: never
+  publishResources: false
+  render: never
 date: '2022-04-22'
 title: Creating a ROSA cluster in STS mode with custom KMS key
 tags: ["ROSA", "ROSA Classic"]


### PR DESCRIPTION
Added 
```
build:
  list: never
  publishResources: false
  render: never

```
RH official docs has custom KMS key + ROSA cluster creation example for [Classic](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/install_rosa_classic_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations_rosa-sts-creating-a-cluster-with-customizations) and [HCP](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-creating-cluster-with-aws-kms-key)