### PR TITLE
Adding RH Design System table styles

### DIFF
--- a/layouts/_default/_markup/render-table.html
+++ b/layouts/_default/_markup/render-table.html
@@ -1,0 +1,51 @@
+{{/* Pipe tables → RHDS Table: https://ux.redhat.com/elements/table/ */}}
+{{- $cols := 0 -}}
+{{- with index .THead 0 -}}
+  {{- $cols = len . -}}
+{{- else -}}
+  {{- with index .TBody 0 -}}
+    {{- $cols = len . -}}
+  {{- end -}}
+{{- end -}}
+<rh-table>
+  <table
+  {{- range $k, $v := .Attributes }}
+    {{- if $v }}
+      {{- printf " %s=%q" $k $v | safeHTMLAttr }}
+    {{- end }}
+  {{- end }}>
+    {{- if gt $cols 0 }}
+    <colgroup>
+      {{- range seq 1 $cols }}
+      <col>
+      {{- end }}
+    </colgroup>
+    {{- end }}
+    <thead>
+      {{- range .THead }}
+      <tr>
+        {{- range . }}
+        <th scope="col"
+          {{- with .Alignment }}
+            {{- printf " style=%q" (printf "text-align: %s" .) | safeHTMLAttr }}
+          {{- end -}}
+        >{{- .Text -}}</th>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </thead>
+    <tbody>
+      {{- range .TBody }}
+      <tr>
+        {{- range . }}
+        <td
+          {{- with .Alignment }}
+            {{- printf " style=%q" (printf "text-align: %s" .) | safeHTMLAttr }}
+          {{- end -}}
+        >{{- .Text -}}</td>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </tbody>
+  </table>
+</rh-table>

--- a/themes/rhds/assets/css/main.css
+++ b/themes/rhds/assets/css/main.css
@@ -1161,6 +1161,14 @@ rh-alert:not(.site-disclaimer) {
   width: 100%;
 }
 
+/* Markdown tables (render hook): same measure as :is(h1,…), p, rh-alert */
+rh-table {
+  box-sizing: border-box;
+  display: block;
+  max-width: 60rem;
+  width: 100%;
+}
+
 rh-blockquote {
   display: block;
   margin-block: var(--rh-space-xl, 24px);

--- a/themes/rhds/layouts/partials/head/css.html
+++ b/themes/rhds/layouts/partials/head/css.html
@@ -5,6 +5,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@rhds/elements@4.0.4/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@rhds/elements@4.0.4/elements/rh-footer/rh-footer-lightdom.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@rhds/elements@4.0.4/elements/rh-tile/rh-tile-lightdom.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@rhds/elements@4.0.4/elements/rh-table/rh-table-lightdom.css">
 <link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}">
 <link rel="stylesheet" href="{{ .RelPermalink }}">
   {{- else }}
@@ -12,6 +13,7 @@
 <link rel="stylesheet" href="https://www.redhatstatic.com/dssf-001/v2/@rhds/elements@4.0.4/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css">
 <link rel="stylesheet" href="https://www.redhatstatic.com/dssf-001/v2/@rhds/elements@4.0.4/elements/rh-footer/rh-footer-lightdom.css">
 <link rel="stylesheet" href="https://www.redhatstatic.com/dssf-001/v2/@rhds/elements@4.0.4/elements/rh-tile/rh-tile-lightdom.css">
+<link rel="stylesheet" href="https://www.redhatstatic.com/dssf-001/v2/@rhds/elements@4.0.4/elements/rh-table/rh-table-lightdom.css">
 <link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}">
 <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
     {{- end }}

--- a/themes/rhds/layouts/partials/head/js.html
+++ b/themes/rhds/layouts/partials/head/js.html
@@ -10,6 +10,7 @@
   import '@rhds/elements/rh-back-to-top/rh-back-to-top.js';
   import '@rhds/elements/rh-tile/rh-tile.js';
   import '@rhds/elements/rh-jump-links/rh-jump-links.js';
+  import '@rhds/elements/rh-table/rh-table.js';
 </script>
 
 <script src="{{ "pagefind/pagefind-ui.js" | relURL }}" defer></script>


### PR DESCRIPTION
- Render GitHub-flavored Markdown pipe tables with the Red Hat Design System **Table** component ([Table element](https://ux.redhat.com/elements/table/)): wrap output in `<rh-table>` with `<colgroup>` / `<col>`, `<thead>` / `<tbody>`, and `th scope="col"`, preserving column alignment and optional block attributes on the inner `<table>`.
- Load **`rh-table.js`** via the existing ES module import map and add **`rh-table-lightdom.css`** in both dev (jsDelivr) and production (redhatstatic) paths, consistent with other RHDS elements.
- Constrain **`rh-table`** to the same **60rem** measure as body copy (`p`, headings, in-body `rh-alert`) so tables are not full width of the main column.