### PR TITLE
Update oTEL guide for OpenShift 4.21 GA status

### DIFF
--- a/content/o11y/otel-instead-of-clf/index.md
+++ b/content/o11y/otel-instead-of-clf/index.md
@@ -1,15 +1,14 @@
 ---
-date: '2025-08-04'
+date: '2024-08-04'
 title: Configuring oTEL to collect OpenShift Logs
-tags: ["Observability"]
+tags: ["Observability", "ROSA HCP"]
 authors:
   - Paul Czarkowski
+validated_version: "4.21"
 ---
 
-{{% alert state="warning" %}}
-The Filelog and JournalD Receivers are a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-
-For more information about the support scope of Red Hat Technology Preview features, see [Technology Preview Features Support Scope](https://access.redhat.com/support/offerings/techpreview/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC).
+{{% alert state="info" %}}
+The Filelog and JournalD Receivers became Generally Available (GA) in OpenShift 4.21, providing full production support with Red Hat SLAs.
 {{% /alert %}}
 
 OpenShift's **Cluster Log Forwarder (CLF)** is the traditional way to collect the cluster's **Audit**, **Infrastructure**, and **Application** logs and forward them to a SIEMs or other central system for log aggregation and visibility.  However the **oTEL Operator** is a bit more flexible, especially when it comes to the output options, for instance the CLF system does not support exporting to **AWS S3**.

--- a/content/o11y/otel-instead-of-clf/index.md
+++ b/content/o11y/otel-instead-of-clf/index.md
@@ -4,6 +4,7 @@ title: Configuring oTEL to collect OpenShift Logs
 tags: ["Observability", "ROSA HCP"]
 authors:
   - Paul Czarkowski
+  - Kumudu Herath
 validated_version: "4.21"
 ---
 
@@ -169,6 +170,7 @@ If you are familiar with Helm, we recommend you go with Option 1 below, if you a
 
     ```bash
     oc -n opentelemetry-logging rollout status ds/ocp-otel-logging-collector
+    ```
 
     ```
     daemon set "ocp-otel-logging-collector" successfully rolled out

--- a/content/o11y/otel-instead-of-clf/index.md
+++ b/content/o11y/otel-instead-of-clf/index.md
@@ -7,8 +7,12 @@ authors:
 validated_version: "4.21"
 ---
 
-{{% alert state="info" %}}
-The Filelog and JournalD Receivers became Generally Available (GA) in OpenShift 4.21, providing full production support with Red Hat SLAs.
+{{% alert state="warning" %}}
+**Receiver Support Status in OpenShift 4.21:**
+- **Filelog Receiver**: Generally Available (GA) - Full production support with Red Hat SLAs
+- **JournalD Receiver**: Technology Preview - Not supported with Red Hat production SLAs and might not be functionally complete. Red Hat does not recommend using it in production.
+
+For more information, see [Technology Preview Features Support Scope](https://access.redhat.com/support/offerings/techpreview).
 {{% /alert %}}
 
 OpenShift's **Cluster Log Forwarder (CLF)** is the traditional way to collect the cluster's **Audit**, **Infrastructure**, and **Application** logs and forward them to a SIEMs or other central system for log aggregation and visibility.  However the **oTEL Operator** is a bit more flexible, especially when it comes to the output options, for instance the CLF system does not support exporting to **AWS S3**.


### PR DESCRIPTION
## Summary

This PR updates the OpenTelemetry logging guide to reflect the accurate GA status of receivers in OpenShift 4.21.

## Changes

- ✅ Updated `validated_version` to `4.21` to enable validation banner
- ✅ Added `ROSA HCP` tag to frontmatter  
- ✅ Fixed date typo (2025-08-04 → 2024-08-04)
- ✅ Updated receiver status to accurately reflect GA vs Technology Preview:
  - **FileLog Receiver**: GA with full production support
  - **JournalD Receiver**: Still Technology Preview
- ✅ Changed alert to provide clear status breakdown for both receivers

## Technical Validation

### FileLog Receiver - GA in OpenShift 4.21
The FileLog Receiver became Generally Available (GA) in OpenShift 4.21, providing full production support with Red Hat SLAs. Red Hat announced "full support of all three observability signals by making log collection generally available (GA), with FileLog Receiver."

**Reference**: [New observability features in Red Hat OpenShift 4.21](https://www.redhat.com/en/blog/new-observability-features-red-hat-openshift-421-and-red-hat-advanced-cluster-management-kubernetes-216)

### JournalD Receiver - Technology Preview
The JournalD Receiver remains in Technology Preview status and is not supported with Red Hat production SLAs.

**Reference**: [Red Hat Build of OpenTelemetry 3.9 - JournalD Receiver](https://docs.redhat.com/en/documentation/red_hat_build_of_opentelemetry/3.9/html/configuring_the_collector/otel-collector-receivers_otel-configuration-of-otel-intro#otel-receivers-journald-receiver_otel-collector-receivers)

Fixes #791

---
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>