### PR TITLE
Initial commit of tested fixes for ROSA OCP Virt article

### DIFF
--- a/content/rosa/ocp-virt/basic.md
+++ b/content/rosa/ocp-virt/basic.md
@@ -30,7 +30,7 @@ If you don't want to deploy the resources yourself, you can watch the video belo
     ```
 
 1. Create a bare metal machine pool
-	> The `c6g.metal` instance type was the cheapest as of the last edit of this document. In general, bare metal instances are expensive, so be careful not to leave them running if they're not in-use.
+	{{% alert state="warning" %}}The `c6g.metal` instance type was the cheapest as of the last edit of this document. In general, bare metal instances are expensive, so be careful not to leave them running if they're not in-use.{{% /warning %}}
 
     ```
      rosa create machine-pool -c $CLUSTER \

--- a/content/rosa/ocp-virt/basic.md
+++ b/content/rosa/ocp-virt/basic.md
@@ -30,7 +30,7 @@ If you don't want to deploy the resources yourself, you can watch the video belo
     ```
 
 1. Create a bare metal machine pool
-	{{% alert state="warning" %}}The `c6g.metal` instance type was the cheapest as of the last edit of this document. In general, bare metal instances are expensive, so be careful not to leave them running if they're not in-use.{{% /warning %}}
+	{{% alert state="warning" %}}The `c6g.metal` instance type was the cheapest as of the last edit of this document. In general, bare metal instances are expensive, so be careful not to leave them running if they're not in-use.{{% /alert %}}
 
     ```
      rosa create machine-pool -c $CLUSTER \
@@ -136,12 +136,13 @@ If you don't want to deploy the resources yourself, you can watch the video belo
     ```
 
 1. Watch for the VM to be ready
-	  > It will take a couple of minutes for the disk image to be provisioned and files copied because this is the first VM to be created on the cluster.
+
+	{{% alert state="info" %}}It will take a couple of minutes for the disk image to be provisioned and files copied because this is the first VM to be created on the cluster.{{% /alert %}}
 
     ```bash
     watch oc get vm example-vm
     ```
-    
+
     ```
     Every 2.0s: oc get vm
     NAME         AGE     STATUS         READY

--- a/content/rosa/ocp-virt/basic.md
+++ b/content/rosa/ocp-virt/basic.md
@@ -6,6 +6,8 @@ authors:
   - Paul Czarkowski
 ---
 
+{{% alert state="info" %}}This guide has been validated on **OpenShift 4.20**. Operator CRD names, API versions, and console paths may differ on other versions.{{% /alert %}}
+
 OpenShift Virtualization is a feature of OpenShift that allows you to run virtual machines alongside your containers.  This is useful for running legacy applications that can't be containerized, or for running applications that require special hardware or software that isn't available in a container.
 
 In this tutorial, I'll show you how to deploy OpenShift Virtualization on Red Hat OpenShift on AWS (ROSA).  I'll show you how to create a ROSA cluster, deploy the OpenShift Virtualization operator, and create a virtual machine.
@@ -21,21 +23,22 @@ If you don't want to deploy the resources yourself, you can watch the video belo
 1. You will need a A ROSA Cluster (see [Deploying ROSA HCP with Terraform](/experts/rosa/terraform/hcp/) if you need help creating one).
 
 1. Set the cluster name as an environment variable (in the example we re-use the variable from the Terraform guide).
-ort METAL_AZ=$(terraform output -json private_subnet_azs | jq -r '.[0]')
-    ```
+
     ```bash
     export CLUSTER="${TF_VAR_cluster_name}"
-    exp
+    export METAL_AZ=$(terraform output -json private_subnet_azs | jq -r '.[0]')
+    ```
 
 1. Create a bare metal machine pool
-	> Note bare metal machines are not cheap, so be warned!
+	> The `c6g.metal` instance type was the cheapest as of the last edit of this document. In general, bare metal instances are expensive, so be careful not to leave them running if they're not in-use.
 
     ```
      rosa create machine-pool -c $CLUSTER \
-       --replicas 1 --availability-zone $METAL_AZ \
-       --instance-type m5zn.metal --name virt
+     --replicas 1 --availability-zone $METAL_AZ \
+     --instance-type m5zn.metal --name virt
     ```
 
+m7i.metal-24xl
 {{< readfile file="/content/rosa/ocp-virt/deploy-operator-cli.md" markdown="true" >}}
 
 ## Create a Virtual Machine
@@ -70,7 +73,7 @@ ort METAL_AZ=$(terraform output -json private_subnet_azs | jq -r '.[0]')
             resources:
               requests:
                 storage: 30Gi
-      running: false
+      runStrategy: Halted
       template:
         metadata:
           labels:
@@ -137,7 +140,8 @@ ort METAL_AZ=$(terraform output -json private_subnet_azs | jq -r '.[0]')
 
     ```bash
     watch oc get vm example-vm
-
+    ```
+    
     ```
     Every 2.0s: oc get vm
     NAME         AGE     STATUS         READY

--- a/content/rosa/ocp-virt/basic.md
+++ b/content/rosa/ocp-virt/basic.md
@@ -35,10 +35,9 @@ If you don't want to deploy the resources yourself, you can watch the video belo
     ```
      rosa create machine-pool -c $CLUSTER \
      --replicas 1 --availability-zone $METAL_AZ \
-     --instance-type m5zn.metal --name virt
+     --instance-type c6g.metal --name virt
     ```
 
-m7i.metal-24xl
 {{< readfile file="/content/rosa/ocp-virt/deploy-operator-cli.md" markdown="true" >}}
 
 ## Create a Virtual Machine
@@ -137,6 +136,7 @@ m7i.metal-24xl
     ```
 
 1. Watch for the VM to be ready
+	  > It will take a couple of minutes for the disk image to be provisioned and files copied because this is the first VM to be created on the cluster.
 
     ```bash
     watch oc get vm example-vm
@@ -151,7 +151,7 @@ m7i.metal-24xl
 1. SSH into the VM
 
     ```bash
-    virtctl ssh cloud-user@example-vm -i ~/.ssh/id_rsa
+    virtctl ssh cloud-user@vm/example-vm -i ~/.ssh/id_rsa
     ```
 
     ```output

--- a/content/rosa/ocp-virt/deploy-operator-cli.md
+++ b/content/rosa/ocp-virt/deploy-operator-cli.md
@@ -28,8 +28,6 @@
       source: redhat-operators
       sourceNamespace: openshift-marketplace
       name: kubevirt-hyperconverged
-      startingCSV: kubevirt-hyperconverged-operator.v4.15.1
-      channel: "stable"
     EOF
     ```
 
@@ -53,6 +51,7 @@
       labels:
         app: kubevirt-hyperconverged
     spec:
+      enableApplicationAwareQuota: false
       applicationAwareConfig:
         allowApplicationAwareClusterResourceQuota: false
         vmiCalcConfigName: DedicatedVirtualResources
@@ -68,15 +67,8 @@
         alignCPUs: false
         autoResourceLimits: false
         deployKubeSecondaryDNS: false
-        deployTektonTaskResources: false
-        deployVmConsoleProxy: false
         disableMDevConfiguration: false
-        enableApplicationAwareQuota: false
-        enableCommonBootImageImport: true
-        enableManagedTenantQuota: false
-        nonRoot: true
         persistentReservation: false
-        withHostPassthroughCPU: false
       infra: {}
       liveMigrationConfig:
         allowAutoConverge: false


### PR DESCRIPTION
Updating ROSA OCP Virt article:

- Added version checked (4.20+) banner to top
- Minor fixes to outdated YAML that threw `deprecated` warnings
- Minor formatting fixes
- Updated bare metal instance type to newer and cheaper `c6g.metal`