### PR TITLE
Add content/examples section with Mermaid diagram reference page

### DIFF
--- a/.claude/skills/triage-prs/SKILL.md
+++ b/.claude/skills/triage-prs/SKILL.md
@@ -157,7 +157,7 @@ Include a prior-comments summary table in the Step 5 report.
 
 - Front matter: `date`, `title`, `tags`, `authors` all present and correct
 - `validated_version` used when appropriate; no redundant version alert callouts
-- No em dashes in content
+- No em dashes in Markdown prose or headings (em dashes inside Mermaid diagram labels are acceptable)
 - Internal links use `/experts/...` root-relative paths (not hardcoded hostnames or Netlify URLs)
 - Shortcodes used correctly (`{{< alert >}}`, `{{< notice >}}`, `{{< tabs >}}`, etc.) — prefer shortcodes over raw blockquotes/HTML for callouts
 - No changes to `themes/rhds` in a content-only PR
@@ -165,6 +165,12 @@ Include a prior-comments summary table in the Step 5 report.
 - `kubectl` → `oc` for OpenShift content
 - No EOL or deprecated container images (e.g. `centos:latest`)
 - `grep -E` instead of `egrep` (`egrep` is deprecated and removed on some systems)
+
+**If the PR touches `content/examples/`**, additionally check:
+- `draft: true` is present in the front matter of every page added or modified — this is required so examples are never published
+- No `tags` in the front matter — example pages are not indexed for user discovery
+- File path follows `content/examples/<topic>/index.md` convention
+- Em dashes are acceptable inside Mermaid diagram source labels but not in Markdown headings or prose
 
 ### Step 4 — Find exact line numbers for suggestions
 
@@ -319,3 +325,5 @@ Confirm the branch has been restored before reporting the review as done.
 - `kubectl` used instead of `oc`
 - Stale/EOL container images
 - Typos or stray characters in YAML/code examples (these break copy-paste)
+- Example page in `content/examples/` missing `draft: true` (page would be published without it)
+- Example page in `content/examples/` with `tags` set (tags pollute the taxonomy and are not useful for internal reference pages)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This repository is a **[Hugo](https://gohugo.io/)** static site using the **`rhd
 - **Chapter / section landing pages** use **`_index.md`** (often `archetype: chapter` and `weight` for menu order).
 - **Individual guides** use **`index.md`** inside a topic directory (for example `content/rosa/some-topic/index.md`).
 - **[`CONTRIBUTING.md`](./CONTRIBUTING.md)** still mentions historical **`/content/docs/...`** paths; prefer the **current** `content/<section>/...` layout unless you are following an explicit maintainer instruction to use `docs/`.
+- **[`content/examples/`](./content/examples/)** is a special section whose `_index.md` cascades `draft: true` to all pages within it. Drafts are rendered by `make preview` (which passes `-D`) but excluded from production builds (`hugo --gc --minify`), so example pages are browsable locally but never published. Use this directory for shortcode demos, diagram templates, or formatting examples. Add new pages as `content/examples/<topic>/index.md`; no extra front matter is needed.
 
 ### Front matter (guides)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,50 @@ authors:
 
 1. Submit PR
 
+## Example pages
+
+The `content/examples/` directory is for shortcode demos, diagram templates, and other formatting references that content authors can copy from. Pages here are **never published** — they render in local preview but are excluded from production builds.
+
+### When to add an example
+
+Add a page to `content/examples/` when you want to:
+
+- Demonstrate a shortcode or Hugo feature for other authors (for example, Mermaid diagrams, tabs, alerts)
+- Provide a copy-paste template for a common content pattern
+- Test a new theme capability before using it in real guides
+
+Do **not** use this section for actual documentation. If content is useful to readers, it belongs in a real section (`rosa/`, `aro/`, `misc/`, etc.).
+
+### How to add an example page
+
+1. Create a directory and `index.md` under `content/examples/`:
+
+   ```
+   content/examples/<topic>/index.md
+   ```
+
+2. Use this front matter — `draft: true` is required so the page is excluded from production builds:
+
+   ```yaml
+   ---
+   date: "YYYY-MM-DD"
+   title: "My example title"
+   draft: true
+   authors:
+     - Your Name
+   ---
+   ```
+
+   Do **not** add `tags` — example pages are not indexed for user discovery.
+
+3. Write your example content and run `make preview` to view it at:
+
+   ```
+   http://localhost:1313/experts/examples/<topic>/
+   ```
+
+4. Submit a PR as normal. The page will be visible in Netlify deploy previews (which pass `--buildDrafts`) but will not appear on the production site.
+
 ## Site search (local development)
 
 The black header bar includes [Pagefind](https://pagefind.app/) client-side search. Netlify runs `npm ci`, builds the site with Hugo, then runs `npx pagefind --site public/experts` so the index is published under `/experts/pagefind/` (see [`netlify.toml`](netlify.toml)).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ If the PR is yours and you want to address reviewer comments, phrase it accordin
 
 Claude will fetch the prior review comments, check what's been addressed and what hasn't, assess the diff, apply fixes locally, and push them back to your branch.
 
+### Example pages
+
+The [`content/examples/`](./content/examples/) directory holds shortcode demos, diagram templates, and other formatting reference pages for content authors. These pages render in local preview (`make preview`) but are never published to the live site. See [CONTRIBUTING.md](./CONTRIBUTING.md#example-pages) for how to add one.
+
 ### Contributing
 
 For contributing to this repository, please follow the guidelines specified in the [contributing.md](./CONTRIBUTING.md)

--- a/content/examples/_index.md
+++ b/content/examples/_index.md
@@ -1,0 +1,7 @@
+---
+title: Examples
+cascade:
+  draft: true
+---
+
+Reference examples for content authors. Pages in this section are never rendered or listed in the built site.

--- a/content/examples/mermaid/index.md
+++ b/content/examples/mermaid/index.md
@@ -1,0 +1,163 @@
+---
+date: 2026-05-29
+title: Mermaid diagram examples
+draft: true
+authors:
+  - Paul Czarkowski
+---
+
+Reference page for Mermaid diagram usage on this site. Add the diagram source inside a `mermaid` shortcode pair.
+
+## Flowchart: ROSA cluster creation flow
+
+{{< mermaid >}}
+flowchart TD
+    A([Start]) --> B[Choose cluster type\nClassic or HCP]
+    B --> C{HCP?}
+    C -- Yes --> D[Create VPC &\nsubnets]
+    C -- No --> E[Select existing VPC\nor let ROSA create]
+    D --> F[rosa create cluster\n--hosted-cp]
+    E --> G[rosa create cluster]
+    F --> H[Wait for install\n~15 min]
+    G --> I[Wait for install\n~45 min]
+    H --> J[Cluster ready]
+    I --> J
+    J --> K[Create admin user\nor configure IDP]
+    K --> L([Done])
+{{< /mermaid >}}
+
+## Sequence diagram: OIDC authentication flow
+
+{{< mermaid >}}
+sequenceDiagram
+    autonumber
+    actor User
+    participant OC as oc / kubectl
+    participant IDP as Identity Provider
+    participant API as OpenShift API Server
+    participant OIDC as OIDC Endpoint
+
+    User->>OC: oc login --web
+    OC->>API: Request OAuth token
+    API-->>OC: Redirect to IDP login
+    OC->>User: Open browser
+    User->>IDP: Enter credentials
+    IDP-->>User: MFA challenge (if configured)
+    User->>IDP: Submit MFA
+    IDP-->>API: OIDC token (id_token)
+    API->>OIDC: Validate token signature
+    OIDC-->>API: Valid
+    API-->>OC: OpenShift session token
+    OC-->>User: Logged in as [username]
+{{< /mermaid >}}
+
+## Architecture diagram: ROSA HCP cluster topology
+
+{{< mermaid >}}
+graph TB
+    subgraph AWS["AWS — Customer account"]
+        subgraph VPC["Customer VPC"]
+            subgraph WN["Worker nodes (EC2)"]
+                P1[Pod] & P2[Pod] & P3[Pod]
+            end
+            LB[AWS Load Balancer]
+            PrivLink[PrivateLink endpoint]
+        end
+    end
+
+    subgraph RH["AWS — Red Hat service account"]
+        subgraph CP["Hosted Control Plane"]
+            API[API Server]
+            ETCD[(etcd)]
+            CTRL[Controller Manager]
+        end
+    end
+
+    Internet((Internet)) -->|HTTPS| LB
+    LB --> WN
+    WN <-->|PrivateLink| PrivLink
+    PrivLink <--> CP
+    API <--> ETCD
+    CTRL <--> API
+{{< /mermaid >}}
+
+## State diagram: Kubernetes Pod lifecycle
+
+{{< mermaid >}}
+stateDiagram-v2
+    [*] --> Pending : Pod scheduled
+
+    Pending --> Init : Init containers start
+    Init --> Running : All init containers complete
+
+    Pending --> Running : No init containers
+
+    Running --> Succeeded : All containers exit 0
+    Running --> Failed : Container exits non-zero\n(restartPolicy: Never)
+    Running --> Running : Container restarts\n(restartPolicy: Always/OnFailure)
+
+    Running --> Terminating : Deletion requested
+    Terminating --> [*] : terminationGracePeriod elapsed
+
+    Succeeded --> [*]
+    Failed --> [*]
+
+    note right of Pending
+        OOMKilled or ImagePullBackOff
+        keeps pod in this state
+    end note
+{{< /mermaid >}}
+
+## Pie chart: Cluster resource allocation example
+
+{{< mermaid >}}
+pie title Cluster vCPU allocation
+    "Application workloads" : 48
+    "Platform / infra" : 12
+    "Monitoring stack" : 8
+    "Reserved (headroom)" : 8
+    "Unallocated" : 24
+{{< /mermaid >}}
+
+## Gantt chart: ROSA upgrade timeline
+
+{{< mermaid >}}
+gantt
+    title ROSA cluster upgrade plan
+    dateFormat  YYYY-MM-DD
+    section Prep
+    Review release notes          :done,    prep1, 2026-06-01, 2d
+    Test in non-prod cluster      :active,  prep2, 2026-06-03, 5d
+    section Maintenance window
+    Notify stakeholders           :         maint1, 2026-06-08, 1d
+    Control plane upgrade         :crit,    maint2, 2026-06-10, 1d
+    Worker node rolling upgrade   :crit,    maint3, 2026-06-10, 2d
+    section Validation
+    Smoke-test workloads          :         val1, 2026-06-12, 1d
+    Monitor for 48 h              :         val2, 2026-06-12, 2d
+    Close change record           :         val3, 2026-06-14, 1d
+{{< /mermaid >}}
+
+## Git graph: Feature branch workflow
+
+{{< mermaid >}}
+gitGraph
+    commit id: "Initial commit"
+    commit id: "Add base config"
+
+    branch feature/add-idp
+    checkout feature/add-idp
+    commit id: "Add LDAP IDP config"
+    commit id: "Add group sync CronJob"
+
+    checkout main
+    branch feature/network-policy
+    checkout feature/network-policy
+    commit id: "Add default deny policy"
+    commit id: "Allow monitoring namespace"
+
+    checkout main
+    merge feature/add-idp id: "Merge IDP feature"
+    merge feature/network-policy id: "Merge network policies"
+    commit id: "Release v1.1"
+{{< /mermaid >}}

--- a/layouts/partials/rhds/footer.html
+++ b/layouts/partials/rhds/footer.html
@@ -75,3 +75,9 @@
   </rh-footer-universal>
 </rh-footer>
 <div id="consent_blackbar" style="position: fixed;bottom: 0;width: 100%;z-index: 5;padding: 10px;"></div>
+{{- if .Store.Get "hasMermaid" }}
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+</script>
+{{- end }}


### PR DESCRIPTION
## Summary

- Adds `content/examples/` — a new section for internal reference pages that render in local preview but are **never published** (cascade `draft: true` excludes them from production builds)
- Adds `content/examples/mermaid/index.md` with 7 working Mermaid diagram examples (flowchart, sequence, architecture, state, pie, Gantt, git graph) using OpenShift/ROSA-relevant content
- Wires Mermaid JS (v11 via CDN) into `layouts/partials/rhds/footer.html`, loaded only on pages that use the `{{< mermaid >}}` shortcode
- Documents the examples convention in `README.md`, `CONTRIBUTING.md`, and `AGENTS.md`
- Updates the `triage-prs` skill to flag missing `draft: true` and unwanted `tags` on example pages, and clarifies that em dashes are acceptable inside Mermaid diagram labels

## Test Plan

- [x] `hugo --gc --minify --theme rhds` builds cleanly with no errors
- [x] `content/examples/` absent from production build output
- [x] All 7 Mermaid diagrams render correctly in `make preview`
- [x] Examples section not visible in site nav or homepage index
- [x] Examples section absent from production RSS and sitemap