### PR TITLE
AWS ROSA: AWS LB Operator outdated values

### DIFF
--- a/content/rosa/aws-load-balancer-operator/index.md
+++ b/content/rosa/aws-load-balancer-operator/index.md
@@ -178,7 +178,6 @@ Compared with default AWS In Tree Provider, this controller is actively develope
      name: aws-load-balancer-operator
      source: redhat-operators
      sourceNamespace: openshift-marketplace
-     startingCSV: aws-load-balancer-operator.v1.0.0
    EOF
    ```
 

--- a/content/rosa/aws-load-balancer-operator/index.md
+++ b/content/rosa/aws-load-balancer-operator/index.md
@@ -173,7 +173,7 @@ Compared with default AWS In Tree Provider, this controller is actively develope
      name: aws-load-balancer-operator
      namespace: aws-load-balancer-operator
    spec:
-     channel: stable-v1.0
+     channel: stable-v1
      installPlanApproval: Automatic
      name: aws-load-balancer-operator
      source: redhat-operators


### PR DESCRIPTION
This PR solves 2 problems with the currently documented `Subscription`:

Issue 1:
`aws-load-balancer-operator` used to be pulled from the channel named `stable-v1.0`, but it seems that has been renamed to `stable-v1`.

Issue 2:
`v1.0.0` of the `aws-load-balancer-operator` is no longer available. Replacing the `startingCSV` with the current value will likely break in the future, hence I opted to remove the `startingCSV` altogether.
